### PR TITLE
Feature/bill integration

### DIFF
--- a/api/migrations/0024_remove_civi_links.py
+++ b/api/migrations/0024_remove_civi_links.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0023_auto_20170615_0827'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='civi',
+            name='links',
+        ),
+    ]

--- a/api/migrations/0025_auto_20170825_1344.py
+++ b/api/migrations/0025_auto_20170825_1344.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0024_remove_civi_links'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='civi',
+            name='bill',
+        ),
+        migrations.AddField(
+            model_name='civi',
+            name='bill',
+            field=models.ManyToManyField(to='api.Bill'),
+        ),
+    ]

--- a/api/models/civi.py
+++ b/api/models/civi.py
@@ -77,7 +77,7 @@ class Civi(models.Model):
     objects = CiviManager()
     author = models.ForeignKey(Account, default=None, null=True)
     thread = models.ForeignKey(Thread, default=None, null=True)
-    bill = models.ForeignKey(Bill, default=None, null=True) # null if not solution
+    bill = models.ManyToManyField(Bill)
 
     hashtags = models.ManyToManyField(Hashtag)
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 import read, write
 
-from api.v1.views import sunlight_api_endpoint
+from api.v1.views import open_states_api_endpoint
 
 #TODO: RESTful API - http://www.django-rest-framework.org/
 urlpatterns = [
@@ -49,5 +49,5 @@ urlpatterns = [
     # url(r'^unpincivi$', write.unpinCivi, name='unpin civi'),
 
     # api
-    url(r'^v1/sunlight/$', sunlight_api_endpoint),
+    url(r'^v1/sunlight/$', open_states_api_endpoint),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 import read, write
 
-from api.v1.views import test_endpoint
+from api.v1.views import sunlight_api_endpoint
 
 #TODO: RESTful API - http://www.django-rest-framework.org/
 urlpatterns = [
@@ -49,5 +49,5 @@ urlpatterns = [
     # url(r'^unpincivi$', write.unpinCivi, name='unpin civi'),
 
     # api
-    url(r'^v1/test/$', test_endpoint),
+    url(r'^v1/sunlight/$', sunlight_api_endpoint),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 import read, write
 
-from api.v1.views import open_states_api_endpoint
+from api.v1.views import open_states_bills
 
 #TODO: RESTful API - http://www.django-rest-framework.org/
 urlpatterns = [

--- a/api/urls.py
+++ b/api/urls.py
@@ -49,5 +49,5 @@ urlpatterns = [
     # url(r'^unpincivi$', write.unpinCivi, name='unpin civi'),
 
     # api
-    url(r'^v1/sunlight/$', open_states_api_endpoint),
+    url(r'^v1/open_states/$', open_states_api_endpoint),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -49,5 +49,5 @@ urlpatterns = [
     # url(r'^unpincivi$', write.unpinCivi, name='unpin civi'),
 
     # api
-    url(r'^v1/open_states/$', open_states_api_endpoint),
+    url(r'^v1/open_states/bills/$', open_states_bills),
 ]

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
 import read, write
 
+from api.v1.views import test_endpoint
+
 #TODO: RESTful API - http://www.django-rest-framework.org/
 urlpatterns = [
     # url(r'^getcivi$', read.getCivi, name='civi'),
@@ -45,4 +47,7 @@ urlpatterns = [
     # url(r'^unfollowgroup$', write.unfollowGroup, name='unfollow group'),
     # url(r'^pincivi$', write.pinCivi, name='pin civi'),
     # url(r'^unpincivi$', write.unpinCivi, name='unpin civi'),
+
+    # api
+    url(r'^v1/test/$', test_endpoint),
 ]

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -1,5 +1,6 @@
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework import status
 import requests
 import pyopenstates as open_states
 
@@ -22,3 +23,8 @@ def open_states_bills(request):
             api_response = open_states.search_bills(q=query)
 
             return Response(api_response)
+        else:
+            return Response(
+                'Must provide search string via "query" parameter',
+                status=status.HTTP_400_BAD_REQUEST
+            )

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -14,7 +14,11 @@ def open_states_api_endpoint(request):
         # Initialize OpenStates with API key
         open_states.set_api_key(open_states_api_key)
 
-        # Get some data from OpenStates API
-        api_response = open_states.search_bills(q='methane')
+        # Get query parameter from request, False if not provided
+        query = request.GET.get('query', False)
 
-        return Response(api_response)
+        if (query):
+            # Get some data from OpenStates API
+            api_response = open_states.search_bills(q=query)
+
+            return Response(api_response)

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -1,0 +1,8 @@
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+@api_view(['GET'])
+def test_endpoint(request):
+    if request.method == 'GET':
+
+        return Response('test response')

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -1,13 +1,20 @@
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 import requests
+import pyopenstates as open_states
 
 from django.conf import settings
 
 @api_view(['GET'])
 def open_states_api_endpoint(request):
     if request.method == 'GET':
-        # Create a request to fake data API
-        api_response = requests.get("https://reqres.in/api/users/2")
+        # Get OpenStates API key
+        open_states_api_key = settings.OPEN_STATES_API_KEY
+
+        # Initialize OpenStates with API key
+        open_states.set_api_key(open_states_api_key)
+
+        # Get some data from OpenStates API
+        api_response = open_states.search_bills(q='methane')
 
         return Response(api_response)

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -1,8 +1,11 @@
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+import requests
 
 @api_view(['GET'])
 def test_endpoint(request):
     if request.method == 'GET':
-
-        return Response('test response')
+        # Create a request to fake data API
+        api_response = requests.get("https://reqres.in/api/users/2")
+        
+        return Response(api_response)

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -2,10 +2,12 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 import requests
 
+from django.conf import settings
+
 @api_view(['GET'])
 def test_endpoint(request):
     if request.method == 'GET':
         # Create a request to fake data API
         api_response = requests.get("https://reqres.in/api/users/2")
-        
+
         return Response(api_response)

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -5,7 +5,7 @@ import requests
 from django.conf import settings
 
 @api_view(['GET'])
-def test_endpoint(request):
+def sunlight_api_endpoint(request):
     if request.method == 'GET':
         # Create a request to fake data API
         api_response = requests.get("https://reqres.in/api/users/2")

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -6,7 +6,7 @@ import pyopenstates as open_states
 from django.conf import settings
 
 @api_view(['GET'])
-def open_states_api_endpoint(request):
+def open_states_bills(request):
     if request.method == 'GET':
         # Get OpenStates API key
         open_states_api_key = settings.OPEN_STATES_API_KEY

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -5,7 +5,7 @@ import requests
 from django.conf import settings
 
 @api_view(['GET'])
-def sunlight_api_endpoint(request):
+def open_states_api_endpoint(request):
     if request.method == 'GET':
         # Create a request to fake data API
         api_response = requests.get("https://reqres.in/api/users/2")

--- a/civiwiki/settings.py
+++ b/civiwiki/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'storages',
     'channels',
     'civiwiki',

--- a/civiwiki/settings.py
+++ b/civiwiki/settings.py
@@ -115,6 +115,7 @@ ADMINS = [('Development Team', 'dev@civiwiki.org')]
 # API keys
 SUNLIGHT_API_KEY = get_env_variable("SUNLIGHT_API_KEY")
 GOOGLE_API_KEY = get_env_variable("GOOGLE_MAP_API_KEY")
+OPEN_STATES_API_KEY = get_env_variable("OPEN_STATES_API_KEY")
 
 # Channels Setup
 if 'REDIS_URL' in os.environ:

--- a/legislation/migrations/0001_initial.py
+++ b/legislation/migrations/0001_initial.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Bill',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('identifier', models.CharField(max_length=255)),
+                ('name', models.CharField(max_length=255)),
+                ('description', models.TextField(max_length=500)),
+            ],
+        ),
+    ]

--- a/legislation/models.py
+++ b/legislation/models.py
@@ -1,3 +1,7 @@
 from django.db import models
 
 # Create your models here.
+class Bill(models.Model):
+    identifier = models.CharField(max_length=255)
+    name = models.CharField(max_length=255)
+    description = models.TextField(max_length=500)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ args==0.1.0
 clint==0.5.1
 Django==1.8.7
 django-cors-headers==1.1.0
+djangorestframework==3.6.3
 docutils==0.12
 gunicorn==19.6.0
 jmespath==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ Twisted==17.1.0
 h2==2.6.1
 priority==1.3.0
 pyOpenSSL==16.2.0
+pyopenstates==1.1.0
 service-identity==16.0.0
 idna==2.5
 celery==4.0.2


### PR DESCRIPTION
Closes #13

# Changes
- Add Django REST Framework
- Add module for API v1
- Add `open_states/bills/` endpoint
  - add `query` parameter
  - when `query` parameter is provided, call is made to Open States Bill Search API
    - result is relayed to client
  - when `query` parameter is omitted, endpoint returns 400 Bad Request
- Add `Bill` model
  - `identifier`
  - `name`
  - `description`
- Modify `Civi` model
  - `bill` field is now ManyToManyField - 
    - multiple bills can be related to a civi and 
    - multiple civies may be related to a bill

# TODO

## Bills API
- determine ideal structure for CiviWiki Open States API endpoint(s).
- add rate limiting to CiviWiki Open States API endpoint(s)
- require user authentication for CiviWiki Open States API endpoint(s)

## Data models
- determine how to model jurisdictions
- determine how to model votes

## Attach bill to Civi

- create 'bill search' form
- after searching for a bill, the user adds it to a Civi
- the bill summary is saved in `Bills` collection
  - including a reference back to the original Bill details on OpenStates platform