### PR TITLE
Remove possible places for hangups from sunlight

### DIFF
--- a/project/api/read.py
+++ b/project/api/read.py
@@ -67,7 +67,7 @@ def get_profile(request, user):
             result['issues'].append(my_issue_item)
 
         result['representatives'] = []
-        rep_ids = sun.get_legislator_ids_by_lat_long(a.latitude, a.longitude)
+        rep_ids = []
 
         for bio_id in rep_ids:
             rep = Representative.objects.get(bioguideID=bio_id)

--- a/project/legislation/sunlightapi.py
+++ b/project/legislation/sunlightapi.py
@@ -1,5 +1,6 @@
 import sunlight
 from django.conf import settings
+from sunlight.errors import BadRequestException
 
 def get_legislator_and_district(account):
     location = account.zip_code
@@ -25,12 +26,12 @@ def get_bill_information(account):
 
 def get_legislator_ids_by_lat_long(latitude, longitude):
     """ Gets legislator bioguide_ids by coordinate location"""
-    # sunlight.config.API_KEY = settings.SUNLIGHT_API_KEY
     bioguide_ids = []
-    # preferences = {}
-    # preferences['state'] = account.state
 
-    legislators = sunlight.congress.locate_legislators_by_lat_lon(latitude, longitude)
+    try:
+        legislators = sunlight.congress.locate_legislators_by_lat_lon(latitude, longitude)
+    except BadRequestException:
+        return bioguide_ids
 
     if legislators and len(legislators):
         for legislator in legislators:

--- a/project/webapp/static/js/utils/locate.js
+++ b/project/webapp/static/js/utils/locate.js
@@ -173,7 +173,7 @@ cw.MapView = BB.View.extend({
             lng: place.geometry.location.lng()
         };
         this.model.set('coordinates', coordinates);
-        this.getLegislators(coordinates);
+        // this.getLegislators(coordinates);
 
         this.adjustMapCenter(coordinates);
         this.$('.progress').toggleClass('hide');
@@ -199,7 +199,7 @@ cw.MapView = BB.View.extend({
                 }
 
                 _this.model.set('coordinates', geolocation);
-                _this.getLegislators(geolocation);
+                // _this.getLegislators(geolocation); # Sunlight API is Deprecated
                 _this.adjustMapCenter(geolocation);
 
                 _this.model.get('geocoder').geocode({ 'location': geolocation }, function(results, status) {


### PR DESCRIPTION
The deprecation of the sunlight API creates hangups in a few pages (profile, and initial user setup page notably) and client-side 500 errors. This simply removes the calls to the sunlight API to stop the hangups.
