### PR TITLE
Fixed Github link, minor text fixes

### DIFF
--- a/project/webapp/templates/static_templates/about.html
+++ b/project/webapp/templates/static_templates/about.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+﻿<!DOCTYPE HTML>
 <!-- About -->
 <head>
     {% load staticfiles %}
@@ -13,7 +13,7 @@
     <div class="content-header center">
         <div class="container section">
             <h2 class="title">About Us</h2>
-            <p class="description">The team that is bringing you civiwiki</p>
+            <p class="description">The team that is bringing you CiviWiki</p>
         </div>
     </div>
     </header>
@@ -26,7 +26,7 @@
                     <div class="divider"></div>
                     <div class="col s12 m8 l10 offset-m2 offset-l1">
                         <h5 class="center">
-                            At CiviWiki we believe democracy works best when citizens are educated on issues and participate in the democratic process. We are a non-profit, non-partisan, community; working to build an open-source platform where citizens discuss the problems they face, discover solutions, and petition their representative to enact change.
+                            At CiviWiki we believe democracy works best when citizens are educated on issues and participate in the democratic process. We are a non-profit, non-partisan community; working to build an open-source platform where citizens discuss the problems they face, discover solutions, and petition their representatives to enact change.
                         </h5>
                     </div>
                 </div>
@@ -44,7 +44,7 @@
                       <h5>A Problem Solving Machine</h5>
                     </div>
                     <div class='collapsible-body container'>
-                      <p class='grey-text  text-darken-2'>We are building a novel, multi-post, discussion platform which allows users to debate issues: why they should care about the issue; what causes the issue; and what policy solutions could solve it. This discussion is then filtered through the community, allowing everyone to rate their agreement with each piece of the debate. Then, the best solutions trend and foster an environment for community consensus to form. </p>
+                      <p class='grey-text  text-darken-2'>We are building a novel, multi-post, discussion platform which allows users to debate issues: why they should care about the issue; what causes the issue; and what policy solutions could solve it. This discussion is then filtered through the community, allowing everyone to rate their agreement with each piece of the debate. Then, the best solutions trend and foster an environment for community consensus to form.</p>
                     </div>
                   </li>
                   <li>
@@ -60,7 +60,7 @@
                       <h5>Smart Petitioning</h5>
                     </div>
                     <div class='collapsible-body container'>
-                      <p class='grey-text  text-darken-2'>Engaging CiviWiki’s discussion is more than simply becoming informed on the issues. We automatically package your support with other likeminded users and use that collective power to petition your representatives. Your representative then has the opportunity to respond to your petition with a voting statement that you can rate. </p>
+                      <p class='grey-text  text-darken-2'>Engaging CiviWiki’s discussion is more than simply becoming informed on the issues. We automatically package your support with other likeminded users and use that collective power to petition your representatives. Your representative then has the opportunity to respond to your petition with a voting statement that you can rate.</p>
                     </div>
                   </li>
                   <li>
@@ -68,7 +68,7 @@
                       <h5>Vote with Confidence</h5>
                     </div>
                     <div class='collapsible-body container'>
-                      <p class='grey-text  text-darken-2'>Your rating history, including why you supported a policy, what policies you supported, and your rating of voting statements are all saved to your account. When elections approach, we compare your CiviWiki history to all potential candidates, helping you make an informed vote. </p>
+                      <p class='grey-text  text-darken-2'>Your rating history, including why you supported a policy, what policies you supported, and your rating of voting statements are all saved to your account. When elections approach, we compare your CiviWiki history to all potential candidates, helping you make an informed vote.</p>
                     </div>
                   </li>
                   <li>
@@ -76,7 +76,7 @@
                       <h5>The Power of CiviWiki</h5>
                     </div>
                     <div class='collapsible-body container'>
-                      <p class='grey-text  text-darken-2'>With traditional voting and petitioning, you vote for the candidate that you believe lines up with your values, and you hope they listen to reasonable petitions. In this process you give away your political power and only recover it the next election cycle. With CiviWiki, you make a credible claim of what factors will influence your next vote. And, since CiviWiki ensures you are reminded of these factors, you retain your voting power between elections. In other words, rather than trusting a politician to make choices for you, CiviWiki allows you to trust that your representative will listen to you.  We are better democracy for the internet age.</p>
+                      <p class='grey-text  text-darken-2'>With traditional voting and petitioning, you vote for the candidate that you believe lines up with your values, and you hope they listen to reasonable petitions. In this process you give away your political power and only recover it the next election cycle. With CiviWiki, you make a credible claim of what factors will influence your next vote. And, since CiviWiki ensures you are reminded of these factors, you retain your voting power between elections. In other words, rather than trusting a politician to make choices for you, CiviWiki allows you to trust that your representative will listen to you. We are better democracy for the internet age.</p>
                     </div>
                   </li>
                 </ul>

--- a/project/webapp/templates/static_templates/static_footer.html
+++ b/project/webapp/templates/static_templates/static_footer.html
@@ -9,7 +9,7 @@
                 <a class="grey-text text-darken-1" href="mailto:mitchell@civiwiki.org">Email</a> |
                 <a class="grey-text text-darken-1" href="https://www.facebook.com/CiviWiki/"  target="_blank">Facebook</a> |
                 <a class="grey-text text-darken-1" href="https://twitter.com/civiwiki"  target="_blank">Twitter</a> |
-                <a class="grey-text text-darken-1" href="https://github.com/CiviWikiorg/CiviWiki"  target="_blank">GitHub</a>
+                <a class="grey-text text-darken-1" href="https://github.com/CiviWiki/OpenCiviWiki"  target="_blank">GitHub</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Fixes issue #144. Also contains some minor text fixes in project/webapp/templates/static_templates/about, which are

-Capitalizing civiwiki to CiviWiki for consistency
-Removing extra comma in sentence
-Changing "representative" to "representatives"
-Removing minor extra whitespace