### PR TITLE
Csv export pull request

### DIFF
--- a/project/civiwiki/settings.py
+++ b/project/civiwiki/settings.py
@@ -51,10 +51,12 @@ INSTALLED_APPS = (
     'frontend_views',
     'notifications',
     'legislation',
+    'corsheaders',
 )
 
 
 MIDDLEWARE_CLASSES = (
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -203,3 +205,6 @@ else:
 # Notification API Settings
 NOTIFICATIONS_SOFT_DELETE = True
 NOTIFICATIONS_USE_JSONFIELD = True
+
+# CORS Settings
+CORS_ORIGIN_ALLOW_ALL = True

--- a/project/frontend_views/urls.py
+++ b/project/frontend_views/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     url(r'^invite$', v.invite, name='invite'),
     url(r'^beta_register/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/(?P<token>\w{31})$', v.beta_register, name='beta_register'),
     url(r'^$', v.base_view, name='base'),
+    url(r'^civi2csv$', v.civi2csv, name='civi2csv'),
 ]

--- a/project/frontend_views/views.py
+++ b/project/frontend_views/views.py
@@ -303,4 +303,4 @@ def civi2csv(request):
         for civi in civiList:
             writer.writerow(civi)
 
-        return JsonResponse({'url': filename})
+        return JsonResponse({'url': '/temp/' + filename})

--- a/project/frontend_views/views.py
+++ b/project/frontend_views/views.py
@@ -2,9 +2,10 @@ import json
 
 from django.conf import settings
 from django.contrib.auth.decorators import user_passes_test
+from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.models import User
 from django.db.models import F
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.template.response import TemplateResponse
 
 from api.models import Category, Account, Thread, Civi, Activity, Invitation
@@ -12,6 +13,12 @@ from api.forms import UpdateProfileImage
 from utils.constants import US_STATES
 from utils.custom_decorators import beta_blocker, login_required, full_account
 
+# Imports for CSV export function
+import random
+import string
+import json
+import bs4
+import csv
 
 def base_view(request):
     if not request.user.is_authenticated():
@@ -266,3 +273,34 @@ def about_view(request):
 
 def support_us_view(request):
     return TemplateResponse(request, 'static_templates/support_us.html', {})
+
+@csrf_exempt
+def civi2csv(request):
+    if request.method == 'POST':
+
+        randomChars = string.ascii_letters + string.digits
+        nonce = ''.join(random.choice(randomChars) for i in range(5))
+        filename = 'cividata-' + nonce + '.csv'
+        file = open('/temp/' + filename, 'w+')
+        writer = csv.writer(file, delimiter=',')
+        civiList = []
+        civis = json.loads(request.body)['civis']
+
+        for civi in civis:
+            civiData = []
+            soup = bs4.BeautifulSoup(civi, 'lxml')
+            civiData.append(soup.find('div', {'class': 'civi-type'}).text.strip())
+            civiData.append(soup.find('span', {'class': 'text-wrapper'}).text.strip())
+            civiData.append(soup.find('div', {'class': 'civi-body-inner'}).text.strip())
+            linkedCivis = soup.findAll('div', {'class': 'link-item'})
+            for link in linkedCivis:
+                civiData.append(link.select('.bold-text')[0].text.strip())
+                civiData.append(link.select('.gray-text')[0].text.strip())
+            civiData.append(soup.find('a', {'class': 'author-name'}).text.strip())
+            civiData.append(soup.find('div', {'class': 'created'}).text.strip())
+            civiList.append(civiData)
+
+        for civi in civiList:
+            writer.writerow(civi)
+
+        return JsonResponse({'url': filename})

--- a/project/webapp/templates/partials/thread/thread_body.html
+++ b/project/webapp/templates/partials/thread/thread_body.html
@@ -1,4 +1,32 @@
 {% verbatim %}
+
+<script>
+  // CSV export Ajax call script
+  $(document).ready(function() {
+
+    cardsHTML = [];
+    cards = document.getElementsByClassName('civi-card');
+    for (i = 0; i < cards.length; i++) {
+      cardsHTML.push(cards[i].innerHTML);
+    }
+
+    $('#csv-export').click(function() {
+      $.ajax({
+        type: 'POST',
+        url: 'http://127.0.0.1:8000/civi2csv',
+        dataType: 'json',
+        data: JSON.stringify({'civis': cardsHTML})
+      }).done(function(response) {
+        var anchor = document.createElement('a');
+        anchor.id = 'csv-link';
+        anchor.href = response.url;
+        document.body.appendChild(anchor);
+        document.getElementById('csv-link').click();
+      }).fail(function(errorThrown) {alert('Error:' + JSON.stringify(errorThrown))});
+    });
+  });
+</script>
+
 <div class="thread-body">
     <nav class="thread-nav body-banner">
         <div class="nav-wrapper">
@@ -30,11 +58,20 @@
                         </div>
                     </div>
                     {{# } }}
-                    <div class="add-button">
-                        <button class="add-civi btn waves-effect right">
-                            <i class="material-icons left">note_add</i>
-                            <span class="text">Add Civi</span>
-                        </button>
+                    <div style="width: 20%">
+                        <div style="display: flex; flex: 1; flex-direction: row;"</div>
+                            <div class="add-button">
+                                <button class="add-civi btn waves-effect right">
+                                    <i class="material-icons left">note_add</i>
+                                    <span class="text">Add Civi</span>
+                                </button>
+                            </div>
+                            <div class="add-button">
+                                <button id="csv-export" class="add-civi btn waves-effect">
+                                    <span class="text">Export to CSV</span>
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
Closes #148, **CSV export option for civi data**. This adds a button to civi threads, next to the "Add Civi" button. The button allows all of the text in each civi card in the thread to be organized into a .csv file which is immediately presented to the user for download without leaving the page. It's done with an Ajax call to the function civi2csv in views.py.

There are a few requirements for it to work properly:
- Python libraries django-cors-headers, bs4, and csv must be installed.
-The (webroot)/temp directory must be available for writing .csv files to.

If there are any problems or you want more information about the feature, you can message me on the riot chat or at j03grassl@gmail.com.