### PR TITLE
Check to make sure the object exists before accessing account images

### DIFF
--- a/project/api/models/account.py
+++ b/project/api/models/account.py
@@ -157,27 +157,27 @@ class Account(models.Model):
     def _get_profile_image_url(self):
         """ Return placeholder profile image if user didn't upload one"""
 
-        file_exists = default_storage.exists(
-            os.path.join(settings.MEDIA_ROOT, self.profile_image.name)
-        )
-        if self.profile_image and file_exists:
-            return self.profile_image.url
-        else:
-            #NOTE: This default url will probably be changed later
-            return "/static/img/no_image_md.png"
+        if self.profile_image:
+            file_exists = default_storage.exists(
+                os.path.join(settings.MEDIA_ROOT, self.profile_image.name)
+            )
+            if file_exists:
+                return self.profile_image.url
+
+        return "/static/img/no_image_md.png"
 
     profile_image_url = property(_get_profile_image_url)
 
     def _get_profile_image_thumb_url(self):
         """ Return placeholder profile image if user didn't upload one"""
 
-        file_exists = default_storage.exists(
-            os.path.join(settings.MEDIA_ROOT, self.profile_image_thumb.name)
-        )
-        if self.profile_image_thumb and file_exists:
-            return self.profile_image_thumb.url
+        if self.profile_image_thumb:
+            file_exists = default_storage.exists(
+                os.path.join(settings.MEDIA_ROOT, self.profile_image_thumb.name)
+            )
+            if file_exists:
+                return self.profile_image_thumb.url
 
-        #NOTE: This default url will probably be changed later
         return "/static/img/no_image_md.png"
 
     profile_image_thumb_url = property(_get_profile_image_thumb_url)


### PR DESCRIPTION
Resolves #174 

The object check has been moved to before the file check for both the profile image and thumbnail url getters. 