### PR TITLE
Add issue guidelines to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,32 @@ python manage.py runserver
 ## Register initial user
 Once CiviWiki is running, visit the front page (probably something like http://localhost:8000). Once there, click 'log in/register', and then 'register new user'.
 
+# Creating Issues
+
+Make sure to search beforehand to see if the issue has been previously reported.
+
+The issue tracker should not be used for personal support requests. Please direct those to our [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org)
+
+## Bug Reports
+Please try to have as much detail as possible when creating a bug report.
+
+A good example should contain:
+
+1. A short description of the issue.
+
+2. Detailed description of the bug, including the environment/OS/Browser info if possible.
+
+3. Steps to reproduce the bug.
+
+4. Any identified lines of code involved in the issue or other insight that may help resolve the issue. This can also include any relevant error logs.
+
+5. (Optional)Potential solutions to the problem.
+
+A good bug report will help direct developers to solve the problem at hand without wasting time trying to figure out the problem in the first place.
+
+## Feature Requests/Enhancements
+If you have a budding idea or a feature that requires a more community-involved discussion, consider having the development discussion on the [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org) or create a thread on [loomio](https://www.loomio.org/g/ET40tXUC/openciviwiki). This will allow for a well-thought-out issue that will more likely be in line with the goal of the project.
+
 # Coding Conventions
 
 We strive to follow Django Coding Conventions. See https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,29 @@
+# Creating Issues
+
+Make sure to search beforehand to see if the issue has been previously reported.
+
+The issue tracker should not be used for personal support requests. Please direct those to our [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org)
+
+## Bug Reports
+Please try to have as much detail as possible when creating a bug report.
+
+A good example should contain:
+
+1. A short description of the issue.
+
+2. Detailed description of the bug, including the environment/OS/Browser info if possible.
+
+3. Steps to reproduce the bug.
+
+4. Any identified lines of code involved in the issue or other insight that may help resolve the issue. This can also include any relevant error logs.
+
+5. (Optional)Potential solutions to the problem.
+
+A good bug report will help direct developers to solve the problem at hand without wasting time trying to figure out the problem in the first place.
+
+## Feature Requests/Enhancements
+If you have a budding idea or a feature that requires a more community-involved discussion, consider having the development discussion on the [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org) or create a thread on [loomio](https://www.loomio.org/g/ET40tXUC/openciviwiki). This will allow for a well-thought-out issue that will more likely be in line with the goal of the project.
+
 # Set-up instructions
 Use these instructions to set up a local development environment.
 
@@ -105,32 +131,6 @@ python manage.py runserver
 
 ## Register initial user
 Once CiviWiki is running, visit the front page (probably something like http://localhost:8000). Once there, click 'log in/register', and then 'register new user'.
-
-# Creating Issues
-
-Make sure to search beforehand to see if the issue has been previously reported.
-
-The issue tracker should not be used for personal support requests. Please direct those to our [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org)
-
-## Bug Reports
-Please try to have as much detail as possible when creating a bug report.
-
-A good example should contain:
-
-1. A short description of the issue.
-
-2. Detailed description of the bug, including the environment/OS/Browser info if possible.
-
-3. Steps to reproduce the bug.
-
-4. Any identified lines of code involved in the issue or other insight that may help resolve the issue. This can also include any relevant error logs.
-
-5. (Optional)Potential solutions to the problem.
-
-A good bug report will help direct developers to solve the problem at hand without wasting time trying to figure out the problem in the first place.
-
-## Feature Requests/Enhancements
-If you have a budding idea or a feature that requires a more community-involved discussion, consider having the development discussion on the [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org) or create a thread on [loomio](https://www.loomio.org/g/ET40tXUC/openciviwiki). This will allow for a well-thought-out issue that will more likely be in line with the goal of the project.
 
 # Coding Conventions
 


### PR DESCRIPTION
Closes #112 

Added an issues section to our contributing guidelines. 
Presents steps to create a bug report and directs feature discussions to our other communication platforms (riot/loomio) until they are well-formed.

@brylie Do you think we should also add an Issue/PR template? Also, not sure how detailed we want to be on this, let me know if I missed anything crucial.