### PR TITLE
Heroku Deployment Instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,9 @@ python manage.py runserver
 ## Register initial user
 Once CiviWiki is running, visit the front page (probably something like http://localhost:8000). Once there, click 'log in/register', and then 'register new user'.
 
+# Deployment
+The [deployment instructions for Heroku](https://github.com/CiviWiki/OpenCiviWiki/wiki/Deployment-instructions-for-Heroku) can be found in the wiki.
+
 # Coding Conventions
 
 We strive to follow Django Coding Conventions. See https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/


### PR DESCRIPTION
Closes #98 

The instructions were placed in the Github Wiki portion of the project repository.