### PR TITLE
Backend API changes for the restructured frontend

### DIFF
--- a/project/api/models/account.py
+++ b/project/api/models/account.py
@@ -139,7 +139,7 @@ class Account(models.Model):
         a CITY, COUNTRY string for locations outside of the US
         """
         if self.country:
-            if self.country is "United States":
+            if self.country == "United States":
                 if self.city and self.state:
                     # Get US State from US States dictionary
                     us_state = dict(US_STATES).get(self.state)
@@ -149,7 +149,7 @@ class Account(models.Model):
                     # Get US State from US States dictionary
                     us_state = dict(US_STATES).get(self.state)
 
-                    return '{state}'.format(us_state)
+                    return '{state}'.format(state=us_state)
                 else:
                     return 'NO LOCATION'
             else:

--- a/project/api/models/civi.py
+++ b/project/api/models/civi.py
@@ -208,6 +208,7 @@ class Civi(models.Model):
             "author": {
                 'username': self.author.user.username,
                 'profile_image': self.author.profile_image_url,
+                'profile_image_thumb_url': self.author.profile_image_thumb_url,
                 'first_name': self.author.first_name,
                 'last_name': self.author.last_name
             },

--- a/project/api/serializers.py
+++ b/project/api/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from api.forms import UpdateProfileImage
-from api.models import Civi, Thread, Account, Category, CiviImage
+from api.models import Civi, Thread, Account, Category, CiviImage, Activity
 from utils.constants import CIVI_TYPES
 
 WRITE_ONLY = {'write_only': True}
@@ -11,28 +11,31 @@ class AccountSerializer(serializers.ModelSerializer):
     """
     General seralizer for a single model instance of a user account
     """
-    email = serializers.EmailField(allow_blank=False, write_only=True, source='user.email', required=False)
+    email = serializers.ReadOnlyField(source='user.email')
     username = serializers.ReadOnlyField(source='user.username')
 
     profile_image = serializers.ImageField(write_only=True, allow_empty_file=False, required=False)
     profile_image_url = serializers.ReadOnlyField()
     profile_image_thumb_url = serializers.ReadOnlyField()
 
-    address = serializers.CharField(allow_blank=True, write_only=True)
-    zip_code = serializers.CharField(allow_blank=True, write_only=True)
+    address = serializers.CharField(allow_blank=True)
+    zip_code = serializers.CharField(allow_blank=True)
 
-    longitude = serializers.FloatField(max_value=180, min_value=-180, write_only=True, required=False)
-    latitude = serializers.FloatField(max_value=90, min_value=-90, write_only=True, required=False)
+    longitude = serializers.FloatField(max_value=180, min_value=-180, required=False)
+    latitude = serializers.FloatField(max_value=90, min_value=-90, required=False)
     location = serializers.ReadOnlyField()
+
+    is_staff = serializers.ReadOnlyField(source='user.is_staff')
+    is_following = serializers.SerializerMethodField()
 
     class Meta:
         model = Account
         fields = ('username', 'first_name', 'last_name', 'about_me', 'location','email',
         'address', 'city', 'state', 'zip_code', 'country', 'longitude', 'latitude',
-        'profile_image', 'profile_image_url', 'profile_image_thumb_url')
+        'profile_image', 'profile_image_url', 'profile_image_thumb_url', 'is_staff',
+        'is_following')
 
         extra_kwargs = {
-            'email': WRITE_ONLY,
             'city': WRITE_ONLY,
             'state': WRITE_ONLY,
             'country': WRITE_ONLY,
@@ -52,6 +55,16 @@ class AccountSerializer(serializers.ModelSerializer):
         else:
             raise serializers.ValidationError(validation_form.errors['profile_image'])
 
+    def get_is_following(self, obj):
+        request = self.context.get("request")
+
+        # Check for authenticated user
+        if request and hasattr(request, "user"):
+            account = Account.objects.get(user=request.user)
+            if obj in account.following.all():
+                return True
+        return False
+
 
 class AccountListSerializer(serializers.ModelSerializer):
     """
@@ -60,12 +73,27 @@ class AccountListSerializer(serializers.ModelSerializer):
     username = serializers.ReadOnlyField(source='user.username')
     first_name = serializers.ReadOnlyField()
     last_name = serializers.ReadOnlyField()
+    location = serializers.ReadOnlyField()
 
+    profile_image_url = serializers.ReadOnlyField()
     profile_image_thumb_url = serializers.ReadOnlyField()
+
+    is_following = serializers.SerializerMethodField()
 
     class Meta:
         model = Account
-        fields = ('username', 'first_name', 'last_name', 'profile_image_thumb_url',)
+        fields = ('username', 'first_name', 'last_name', 'profile_image_url',
+        'profile_image_thumb_url', 'location', 'is_following')
+
+    def get_is_following(self, obj):
+        request = self.context.get("request")
+
+        # Check for authenticated user
+        if request and hasattr(request, "user"):
+            account = Account.objects.get(user=request.user)
+            if obj in account.following.all():
+                return True
+        return False
 
 
 class CiviImageSerializer(serializers.ModelSerializer):
@@ -74,26 +102,33 @@ class CiviImageSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CiviImage
-        fields = ('civi', 'title', 'image_url', 'created')
+        fields = ('id', 'civi', 'title', 'image_url', 'created')
 
 
 class CiviSerializer(serializers.ModelSerializer):
     author = AccountListSerializer()
     type = serializers.ChoiceField(choices=CIVI_TYPES, source='c_type')
     images = serializers.SlugRelatedField(many=True, read_only=True, slug_field='image_url')
+    attachments = CiviImageSerializer(many=True, source='images')
     created = serializers.ReadOnlyField(source='created_date_str')
     score = serializers.SerializerMethodField()
+    links = serializers.PrimaryKeyRelatedField(many=True, read_only=True, source="linked_civis")
 
     class Meta:
         model = Civi
         fields = ('id', 'thread', 'type', 'title', 'body', 'author', 'created', 'last_modified',
-        'votes', 'images', 'linked_civis', 'responses', 'score')
+        'votes', 'images', 'linked_civis', 'links', 'responses', 'score', 'attachments')
 
     def get_score(self, obj):
         user = None
         request = self.context.get("request")
+
+        # Check for authenticated user
         if request and hasattr(request, "user"):
             user = request.user
+        else:
+            return 0
+
         if user.is_anonymous():
             return 0
         else:
@@ -110,15 +145,40 @@ class CiviListSerializer(serializers.ModelSerializer):
         model = Civi
         fields = ('id', 'thread', 'type', 'title', 'body', 'author', 'created')
 
-class CategorySerializer(serializers.ModelSerializer):
+
+class CategoryListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Category
         fields = ('id', 'name')
 
 
+class CategorySerializer(serializers.ModelSerializer):
+    preferred = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Category
+        fields = ('id', 'name', 'preferred')
+
+    def get_preferred(self, obj):
+        user = None
+        request = self.context.get("request")
+
+        # Check for authenticated user
+        if request and hasattr(request, "user"):
+            user = request.user
+        else:
+            return True
+
+        if user.is_anonymous():
+            return True
+
+        account = Account.objects.get(user=user)
+        return obj.id in account.categories.values_list('id', flat=True)
+
+
 class ThreadSerializer(serializers.ModelSerializer):
     author = AccountListSerializer(required=False)
-    category = serializers.PrimaryKeyRelatedField(queryset=Category.objects.all())
+    category = CategoryListSerializer()
 
     civis = serializers.HyperlinkedRelatedField(many=True, view_name='civi-detail', read_only=True)
     created = serializers.ReadOnlyField(source='created_date_str')
@@ -133,3 +193,56 @@ class ThreadSerializer(serializers.ModelSerializer):
         fields = ('id', 'title', 'summary', 'author', 'image_url', 'civis', 'image',
         'created', 'level', 'state', 'is_draft', 'category',
         'num_views', 'num_civis', 'num_solutions')
+
+
+class ThreadListSerializer(serializers.ModelSerializer):
+    author = AccountListSerializer(required=False)
+    category = CategoryListSerializer()
+
+    created = serializers.ReadOnlyField()
+
+    num_views = serializers.ReadOnlyField()
+    num_civis = serializers.ReadOnlyField()
+    num_solutions = serializers.ReadOnlyField()
+
+    class Meta:
+        model = Thread
+        fields = ('id', 'title', 'summary', 'author', 'image_url', 'created',
+        'level', 'state', 'is_draft', 'category', 'num_views', 'num_civis',
+        'num_solutions')
+
+
+class ThreadDetailSerializer(serializers.ModelSerializer):
+    author = AccountListSerializer(required=False)
+    category = CategoryListSerializer()
+
+    civis = CiviSerializer(many=True)
+    created = serializers.ReadOnlyField(source='created_date_str')
+    image = serializers.ImageField(write_only=True, allow_empty_file=False, required=False)
+
+    num_views = serializers.ReadOnlyField()
+    num_civis = serializers.ReadOnlyField()
+    num_solutions = serializers.ReadOnlyField()
+
+    contributors = serializers.SerializerMethodField()
+    user_votes = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Thread
+        fields = ('id', 'title', 'summary', 'author', 'image_url', 'civis', 'image',
+        'created', 'level', 'state', 'is_draft', 'category',
+        'num_views', 'num_civis', 'num_solutions', 'contributors', 'user_votes')
+
+    def get_contributors(self, obj):
+        issue_civis = Civi.objects.filter(thread__id=obj.id)
+        contributor_accounts = Account.objects.filter(pk__in=issue_civis.distinct('author').values_list('author', flat=True))
+        return AccountListSerializer(contributor_accounts, many=True).data
+
+    def get_user_votes(self, obj):
+        request = self.context.get("request")
+
+        if request and hasattr(request, "user"):
+            user_activities = Activity.objects.filter(thread=obj.id, account=request.user.id)
+            return [{'civi_id':activity.civi.id, 'activity_type': activity.activity_type, 'c_type': activity.civi.c_type} for activity in user_activities]
+        else:
+            return []

--- a/project/api/urls.py
+++ b/project/api/urls.py
@@ -5,7 +5,7 @@ from rest_framework.documentation import include_docs_urls
 from api import views, read, write
 
 
-router = DefaultRouter(trailing_slash=False)
+router = DefaultRouter()
 router.register(r'threads', views.ThreadViewSet)
 router.register(r'categories', views.CategoryViewSet)
 router.register(r'accounts', views.AccountViewSet)

--- a/project/api/views.py
+++ b/project/api/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework import authentication, permissions, viewsets
 from rest_framework.decorators import (
     api_view,
-    detail_route,
+    action
 )
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -17,11 +17,13 @@ from rest_framework.reverse import reverse
 from api.models import Thread, Account, Category, Civi, CiviImage
 from api.serializers import (
     ThreadSerializer,
+    ThreadListSerializer,
+    ThreadDetailSerializer,
     CategorySerializer,
     CiviSerializer,
     CiviImageSerializer,
     AccountSerializer,
-    AccountListSerializer,
+    AccountListSerializer
 )
 
 
@@ -86,7 +88,7 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
 
-    @detail_route()
+    @action(detail=True)
     def threads(self, request, pk=None):
         category_threads = Thread.objects.filter_by_category_id(pk)
         serializer = ThreadSerializer(category_threads, many=True)
@@ -116,8 +118,16 @@ class AccountViewSet(viewsets.ModelViewSet):
             accounts = Account.objects.filter(user=self.request.user)
         serializer = AccountListSerializer(accounts, many=True)
         return Response(serializer.data)
+    
+    def retrieve(self, request, user__username=None):
+        account = get_account(username=user__username)
+        if (self.request.user == account.user):
+            serializer = AccountSerializer(account)
+        else:
+            serializer = AccountListSerializer(account)
+        return Response(serializer.data)
 
-    @detail_route()
+    @action(detail=True)
     def civis(self, request, user__username=None):
         """
         Gets the civis of the selected account
@@ -128,7 +138,7 @@ class AccountViewSet(viewsets.ModelViewSet):
         serializer = CiviSerializer(account_civis, many=True)
         return Response(serializer.data)
 
-    @detail_route()
+    @action(detail=True)
     def followers(self, request, user__username=None):
         """
         Gets the followers of the selected account
@@ -139,7 +149,7 @@ class AccountViewSet(viewsets.ModelViewSet):
         serializer = AccountListSerializer(account_followers, many=True)
         return Response(serializer.data)
 
-    @detail_route()
+    @action(detail=True)
     def following(self, request, user__username=None):
         """
         Gets the followings of the selected account
@@ -150,26 +160,105 @@ class AccountViewSet(viewsets.ModelViewSet):
         serializer = AccountListSerializer(account_followings, many=True)
         return Response(serializer.data)
 
+    @action(detail=True)
+    def categories(self, request, user__username=None):
+        """
+        Gets the preferred categories of the selected account
+        /accounts/{username}/categories
+        """
+        account = get_account(username=user__username)
+        account_categories = account.categories
+        serializer = CategorySerializer(account_categories, many=True)
+        return Response(serializer.data)
+
+    @action(detail=True)
+    def threads(self, request, user__username=None):
+        """
+        Gets the preferred categories of the selected account
+        /accounts/{username}/categories
+        """
+        account = get_account(username=user__username)
+        draft_threads = Thread.objects.filter(author=account).exclude(is_draft=False)
+        serializer = ThreadSerializer(draft_threads, many=True, context={'request': request})
+        return Response(serializer.data)
+
+    @action(detail=True)
+    def drafts(self, request, user__username=None):
+        """
+        Gets the draft threads of the selected account
+        /accounts/{username}/drafts
+        """
+        account = get_account(username=user__username)
+        draft_threads = Thread.objects.filter(author=account, is_draft=False)
+        serializer = ThreadSerializer(draft_threads, many=True, context={'request': request})
+        return Response(serializer.data)
 
 class ThreadViewSet(viewsets.ModelViewSet):
     """ REST API viewset for Threads """
 
-    queryset = Thread.objects.all()
-    serializer_class = ThreadSerializer
+    queryset = Thread.objects.order_by('-created')
+    serializer_class = ThreadDetailSerializer
     permission_classes = (IsOwnerOrReadOnly,)
     authentication_classes = AUTH_CLASSES
+
+    def list(self, request):
+        threads = Thread.objects.filter(is_draft=False).order_by('-created')
+        serializer = ThreadSerializer(threads, many=True, context={'request': request})
+        return Response(serializer.data)
+
+    def get_queryset(self):
+        """ allow rest api to filter by submissions """
+        queryset = Thread.objects.all()
+        category_id = self.request.query_params.get('category_id', None)
+        if category_id is not None:
+            if category_id != 'all':
+                queryset = queryset.filter(category=category_id)
+
+        return queryset
 
     def perform_create(self, serializer):
         serializer.save(author=get_account(user=self.request.user))
 
-    @detail_route()
+    @action(detail=True)
     def civis(self, request, pk=None):
         """
         Gets the civis linked to the thread instance
-        /accounts/{username}/civis
+        /threads/{id}/civis
         """
-        thread_civis = Civi.objects.filter_by_thread_id(pk)
+        thread_civis = Civi.objects.filter(thread=pk)
         serializer = CiviSerializer(thread_civis, many=True)
+        return Response(serializer.data)
+
+    @action(methods=['get', 'post'], detail=False)
+    def all(self, request):
+        """
+        Gets the all threads for listing
+        /threads/all
+        """
+        all_threads = self.queryset
+        serializer = ThreadListSerializer(all_threads, many=True, context={'request': request})
+        return Response(serializer.data)
+
+    @action(methods=['get', 'post'], detail=False)
+    def top(self, request):
+        """
+        Gets the top threads based on the number of page views
+        /threads/top
+        """
+        limit = request.query_params.get('limit', 5)
+        top_threads = Thread.objects.filter(is_draft=False).order_by('-num_views')[:limit]
+        serializer = ThreadListSerializer(top_threads, many=True, context={'request': request})
+        return Response(serializer.data)
+
+    @action(detail=False)
+    def drafts(self, request):
+        """
+        Gets the drafts of the current authenticated user
+        /threads/drafts
+        """
+        account = get_account(username=self.request.user)
+        draft_threads = Thread.objects.filter(author=account, is_draft=True)
+        serializer = ThreadListSerializer(draft_threads, many=True, context={'request': request})
         return Response(serializer.data)
 
 class CiviViewSet(viewsets.ModelViewSet):
@@ -183,11 +272,11 @@ class CiviViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         serializer.save(author=get_account(user=self.request.user))
 
-    @detail_route()
+    @action(detail=True)
     def images(self, request, pk=None):
         """
         Gets the related images
-        /accounts/{username}/images
+        /civis/{id}/images
         """
         civi_images = CiviImage.objects.filter(civi=pk)
         serializer = CiviImageSerializer(civi_images, many=True, read_only=True)

--- a/project/api/write.py
+++ b/project/api/write.py
@@ -445,7 +445,7 @@ def uploadCiviImage(request):
                     civi_image.save()
 
             data = {
-                "attachments": [{'id': img.id, 'url': img.image_url} for img in c.images.all()],
+                "attachments": [{'id': img.id, 'image_url': img.image_url} for img in c.images.all()],
             }
             return JsonResponse(data)
 


### PR DESCRIPTION
This PR separates out the backend changes in #205 for faster review.
- Modifies previous read/write calls and adds additional routes and serializers within the DRF based api to help connect to the restructured frontend
- Django Rest Framework is upgraded to 3.8 and uses the `action` decorator as opposed to the deprecated `detail_view` and `list_view` decorators