### PR TITLE
Update DRF to 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ django-cors-headers==2.1.0
 django-model-utils==3.0.0
 django-notifications-hq==1.3
 django-storages==1.6.5
-djangorestframework==3.6.3
+djangorestframework==3.8.2
 docutils==0.14
 enum34==1.1.6
 flake8==3.4.1


### PR DESCRIPTION
Updates the Django Rest Framework version specified in the requirement.txt file from 3.6 to 3.8
Fixes the issue in the current deployed dev branch.