### PR TITLE
Thread edit refresh

### DIFF
--- a/project/webapp/static/js/thread.js
+++ b/project/webapp/static/js/thread.js
@@ -1796,7 +1796,7 @@ cw.ThreadView = BB.View.extend({
         this.resizeBodyToWindow();
 
         this.renderOutline();//THISTHIS
-        this.renderBodyContents();
+        
         this.processCiviScroll();
     },
 

--- a/project/webapp/static/js/thread.js
+++ b/project/webapp/static/js/thread.js
@@ -1359,7 +1359,6 @@ cw.ThreadView = BB.View.extend({
     outlineTemplate: _.template($('#outline-template').html()),
 
     initialize: function (options) {
-        console.log('sanity check')
         options = options || {};
         this.username = options.username;
         this.civis = options.civis;
@@ -1519,6 +1518,8 @@ cw.ThreadView = BB.View.extend({
         }
     },
 
+    // Renders thread navbar element independently of main body.
+    // Useful for updating after thread edits are saved.
     threadNavRender: function () {
       var _this = this;
       var navRenderData = {
@@ -1804,7 +1805,7 @@ cw.ThreadView = BB.View.extend({
 
         this.resizeBodyToWindow();
 
-        this.renderOutline();//THISTHIS
+        this.renderOutline();
 
         this.processCiviScroll();
     },

--- a/project/webapp/static/js/thread.js
+++ b/project/webapp/static/js/thread.js
@@ -1184,6 +1184,8 @@ cw.EditThreadView = BB.View.extend({
                                     _this.parentView.model.set('state', new_data.state);
                                     _this.parentView.model.set('location', new_data.location);
                                     _this.parentView.model.set('image', response2.image);
+                                    _this.parentView.threadBodyRender();
+                                    _this.parentView.renderBodyContents();
                                     _this.parentView.threadWikiRender();
 
                                 },
@@ -1219,6 +1221,8 @@ cw.EditThreadView = BB.View.extend({
                                     _this.parentView.model.set('state', new_data.state);
                                     _this.parentView.model.set('location', new_data.location);
                                     _this.parentView.model.set('image', response2.image);
+                                    _this.parentView.threadBodyRender();
+                                    _this.parentView.renderBodyContents();
                                     _this.parentView.threadWikiRender();
                                 },
                                 error: function(e){
@@ -1248,6 +1252,8 @@ cw.EditThreadView = BB.View.extend({
                                     _this.parentView.model.set('level', new_data.level);
                                     _this.parentView.model.set('state', new_data.state);
                                     _this.parentView.model.set('location', new_data.location);
+                                    _this.parentView.threadBodyRender();
+                                    _this.parentView.renderBodyContents();
                                     _this.parentView.threadWikiRender();
                                 },
                                 error: function(e){
@@ -1270,6 +1276,8 @@ cw.EditThreadView = BB.View.extend({
                         _this.parentView.model.set('level', new_data.level);
                         _this.parentView.model.set('state', new_data.state);
                         _this.parentView.model.set('location', new_data.location);
+                        _this.parentView.threadBodyRender();
+                        _this.parentView.renderBodyContents();
                         _this.parentView.threadWikiRender();
                     }
 
@@ -1781,14 +1789,14 @@ cw.ThreadView = BB.View.extend({
 
     scrollToBody: function () {
         var _this = this;
-
         this.$('.thread-wiki-holder').addClass('hide');
         this.$('.thread-body-holder').removeClass('hide');
         this.$('.thread-body-holder').css({display: 'block'});
 
         this.resizeBodyToWindow();
 
-        this.renderOutline();
+        this.renderOutline();//THISTHIS
+        this.renderBodyContents();
         this.processCiviScroll();
     },
 

--- a/project/webapp/static/js/thread.js
+++ b/project/webapp/static/js/thread.js
@@ -1187,6 +1187,7 @@ cw.EditThreadView = BB.View.extend({
                                     _this.parentView.threadBodyRender();
                                     _this.parentView.renderBodyContents();
                                     _this.parentView.threadWikiRender();
+                                    _this.parentView.threadNavRender();
 
                                 },
                                 error: function(e){
@@ -1224,6 +1225,7 @@ cw.EditThreadView = BB.View.extend({
                                     _this.parentView.threadBodyRender();
                                     _this.parentView.renderBodyContents();
                                     _this.parentView.threadWikiRender();
+                                    _this.parentView.threadNavRender();
                                 },
                                 error: function(e){
                                     Materialize.toast('ERROR: Image could not be uploaded', 5000);
@@ -1255,6 +1257,7 @@ cw.EditThreadView = BB.View.extend({
                                     _this.parentView.threadBodyRender();
                                     _this.parentView.renderBodyContents();
                                     _this.parentView.threadWikiRender();
+                                    _this.parentView.threadNavRender();
                                 },
                                 error: function(e){
                                     Materialize.toast('ERROR: Image could not be uploaded', 5000);
@@ -1279,6 +1282,7 @@ cw.EditThreadView = BB.View.extend({
                         _this.parentView.threadBodyRender();
                         _this.parentView.renderBodyContents();
                         _this.parentView.threadWikiRender();
+                        _this.parentView.threadNavRender();
                     }
 
                 },
@@ -1358,10 +1362,12 @@ cw.ThreadView = BB.View.extend({
     template: _.template($('#thread-template').html()),
     wikiTemplate: _.template($('#thread-wiki-template').html()),
     bodyTemplate: _.template($('#thread-body-template').html()),
+    navTemplate: _.template($('#thread-nav-template').html()),
     responseWrapper: _.template($('#thread-response-template').html()),
     outlineTemplate: _.template($('#outline-template').html()),
 
     initialize: function (options) {
+        console.log('sanity check')
         options = options || {};
         this.username = options.username;
         this.civis = options.civis;
@@ -1485,6 +1491,7 @@ cw.ThreadView = BB.View.extend({
 
         this.threadWikiRender();
         this.threadBodyRender();
+        this.threadNavRender();
 
         // this.$('.scroll-col').height($(window).sheight() - this.$('.body-banner').height());
 
@@ -1514,11 +1521,21 @@ cw.ThreadView = BB.View.extend({
                 is_draft: this.is_draft,
             };
             this.$('.thread-body-holder').empty().append(this.bodyTemplate(bodyRenderData));
-
             this.$('.main-thread').on('scroll', function (e) {
                 _this.processCiviScroll();
             });
         }
+    },
+
+    threadNavRender: function () {
+      var _this = this;
+      var navRenderData = {
+          is_draft: this.is_draft,
+      };
+      this.$('.thread-nav').empty().append(this.navTemplate(navRenderData));
+      this.$('.main-thread').on('scroll', function (e) {
+            _this.processCiviScroll();
+      });
     },
 
     renderBodyContents: function () {

--- a/project/webapp/static/js/thread.js
+++ b/project/webapp/static/js/thread.js
@@ -1184,8 +1184,6 @@ cw.EditThreadView = BB.View.extend({
                                     _this.parentView.model.set('state', new_data.state);
                                     _this.parentView.model.set('location', new_data.location);
                                     _this.parentView.model.set('image', response2.image);
-                                    _this.parentView.threadBodyRender();
-                                    _this.parentView.renderBodyContents();
                                     _this.parentView.threadWikiRender();
                                     _this.parentView.threadNavRender();
 
@@ -1222,8 +1220,6 @@ cw.EditThreadView = BB.View.extend({
                                     _this.parentView.model.set('state', new_data.state);
                                     _this.parentView.model.set('location', new_data.location);
                                     _this.parentView.model.set('image', response2.image);
-                                    _this.parentView.threadBodyRender();
-                                    _this.parentView.renderBodyContents();
                                     _this.parentView.threadWikiRender();
                                     _this.parentView.threadNavRender();
                                 },
@@ -1254,8 +1250,6 @@ cw.EditThreadView = BB.View.extend({
                                     _this.parentView.model.set('level', new_data.level);
                                     _this.parentView.model.set('state', new_data.state);
                                     _this.parentView.model.set('location', new_data.location);
-                                    _this.parentView.threadBodyRender();
-                                    _this.parentView.renderBodyContents();
                                     _this.parentView.threadWikiRender();
                                     _this.parentView.threadNavRender();
                                 },
@@ -1279,8 +1273,6 @@ cw.EditThreadView = BB.View.extend({
                         _this.parentView.model.set('level', new_data.level);
                         _this.parentView.model.set('state', new_data.state);
                         _this.parentView.model.set('location', new_data.location);
-                        _this.parentView.threadBodyRender();
-                        _this.parentView.renderBodyContents();
                         _this.parentView.threadWikiRender();
                         _this.parentView.threadNavRender();
                     }
@@ -1813,7 +1805,7 @@ cw.ThreadView = BB.View.extend({
         this.resizeBodyToWindow();
 
         this.renderOutline();//THISTHIS
-        
+
         this.processCiviScroll();
     },
 

--- a/project/webapp/templates/partials/thread/thread_body.html
+++ b/project/webapp/templates/partials/thread/thread_body.html
@@ -1,50 +1,6 @@
 {% verbatim %}
 <div class="thread-body">
-    <nav class="thread-nav body-banner">
-        <div class="nav-wrapper">
-            <div class="nav-categories nav-item">
-                <div id="thread-meta">
-                    <div class="meta-item">
-                        <span class="location"></span>
-                    </div>
-                    <div class="meta-item">
-                        <span class="thread-location">({{this.model.get('location')}})</span>
-                    </div>
-                    <div class="meta-item">
-                        <span class="body-category">{{this.model.get('category').name}}</span>
-                    </div>
-
-                    <div class="meta-item">
-                        <i class="mini material-icons">keyboard_arrow_right</i>
-                    </div>
-                    <div class="meta-item title-item">
-                        <span class="thread-title">{{this.model.get('title')}}</span>
-                        <i class="tiny material-icons background-info-link enter-wiki">assignment</i>
-                    </div>
-                    {{# if (is_draft) { }}
-                    <div class="meta-item">
-                        <div class="add-button">
-                            <button class="publish-thread btn waves-effect dark-blue-background" id="js-publish-btn">
-                                <span class="text">Publish Thread</span>
-                            </button>
-                        </div>
-                    </div>
-                    {{# } }}
-                    <div class="add-button">
-                        <button class="add-civi btn waves-effect right">
-                            <i class="material-icons left">note_add</i>
-                            <span class="text">Add Civi</span>
-                        </button>
-                    </div>
-                    <div class="add-button" style="margin-left: 4px">
-                        <a id="csv-export" href="{{this.model.get('thread_id')}}/csv" class="btn waves-effect">
-                            <span class="text">Export</span>
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </nav>
+    <nav class="thread-nav body-banner"></nav>
     <div class="col nav-column civi-outline">
         <div class="issue-outline">
             <div class="issue-outline-header gray-text bold-text">

--- a/project/webapp/templates/partials/thread/thread_nav.html
+++ b/project/webapp/templates/partials/thread/thread_nav.html
@@ -1,0 +1,45 @@
+{% verbatim %}
+    <div class="nav-wrapper">
+        <div class="nav-categories nav-item">
+            <div id="thread-meta">
+                <div class="meta-item">
+                    <span class="location"></span>
+                </div>
+                <div class="meta-item">
+                    <span class="thread-location">({{this.model.get('location')}})</span>
+                </div>
+                <div class="meta-item">
+                    <span class="body-category">{{this.model.get('category').name}}</span>
+                </div>
+
+                <div class="meta-item">
+                    <i class="mini material-icons">keyboard_arrow_right</i>
+                </div>
+                <div class="meta-item title-item">
+                    <span class="thread-title">{{this.model.get('title')}}</span>
+                    <i class="tiny material-icons background-info-link enter-wiki">assignment</i>
+                </div>
+                {{# if (is_draft) { }}
+                <div class="meta-item">
+                    <div class="add-button">
+                        <button class="publish-thread btn waves-effect dark-blue-background" id="js-publish-btn">
+                            <span class="text">Publish Thread</span>
+                        </button>
+                    </div>
+                </div>
+                {{# } }}
+                <div class="add-button">
+                    <button class="add-civi btn waves-effect right">
+                        <i class="material-icons left">note_add</i>
+                        <span class="text">Add Civi</span>
+                    </button>
+                </div>
+                <div class="add-button" style="margin-left: 4px">
+                    <a id="csv-export" href="{{this.model.get('thread_id')}}/csv" class="btn waves-effect">
+                        <span class="text">Export</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endverbatim %}

--- a/project/webapp/templates/thread.html
+++ b/project/webapp/templates/thread.html
@@ -17,9 +17,15 @@
     {% include "partials/thread/edit_wiki.html" %}
 </script>
 
+
+<script id="thread-nav-template" type="text/template">
+    {% include "partials/thread/thread_nav.html" %}
+</script>
+
 <script id="thread-body-template" type="text/template">
     {% include "partials/thread/thread_body.html" %}
 </script>
+
 
 <script id="thread-response-template" type="text/template">
     {% include "partials/thread/thread_responses.html" %}


### PR DESCRIPTION
Simple fix calls render functions to update thread info after edit.

While working on this I noticed (in firefox) the scroll after returning from the edit window hides the title bar. Will look into this too.

@jl24 review request

Update: Extra commits after realising the civi scroll was disrupted at first

Resolves #213 