### PR TITLE
Closes #221

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ configparser==3.5.0
 constantly==15.1.0
 coreapi==2.3.3
 coverage==4.4.1
-cryptography==2.1.3
+cryptography==2.3.1
 daphne==1.3.0
 dj-database-url==0.4.2
 Django==1.11.7


### PR DESCRIPTION
Updates version number for pyca/cryptography package. Due to some security issues the package needed to be updated.

Package was updated to 2.3.1 

For reference: [cryptography](https://cryptography.io/en/latest/changelog/#v2-3-1 )