### PR TITLE
Making state/location visable from feed page

### DIFF
--- a/project/api/models/thread.py
+++ b/project/api/models/thread.py
@@ -28,7 +28,6 @@ class ThreadManager(models.Manager):
             "summary": thread.summary[:thread_truncate_length] + (ellipsis_if_too_long),
             "created": "{0} {1}, {2}".format(month_name[thread.created.month], thread.created.day, thread.created.year),
             "category_id": thread.category.id,
-            "state": thread.state if thread.level == "state" else "federal",
             "location": thread.level if not thread.state else dict(US_STATES).get(thread.state),
             "image": thread.image_url
         }

--- a/project/api/models/thread.py
+++ b/project/api/models/thread.py
@@ -28,6 +28,8 @@ class ThreadManager(models.Manager):
             "summary": thread.summary[:thread_truncate_length] + (ellipsis_if_too_long),
             "created": "{0} {1}, {2}".format(month_name[thread.created.month], thread.created.day, thread.created.year),
             "category_id": thread.category.id,
+            "state": thread.state if thread.level == "state" else "federal",
+            "location": thread.level if not thread.state else dict(US_STATES).get(thread.state),
             "image": thread.image_url
         }
         author_data = {

--- a/project/webapp/templates/partials/feed/thread_card.html
+++ b/project/webapp/templates/partials/feed/thread_card.html
@@ -8,9 +8,9 @@
             </div>
         </div>
         <div class="content col s9">
-            <div class="thread-category">{{= categories[thread_data.thread.category_id].name }}</div>
+            <div class="thread-category">({{ thread_data.thread.location }}) {{= categories[thread_data.thread.category_id].name }}</div>
             <a href="thread/{{thread_data.thread.id}}">
-                <div class="thread-title">{{ thread_data.thread.title }}</div>
+		    <div class="thread-title">{{ thread_data.thread.title }}</div>
                 <div class="thread-summary">{{ thread_data.thread.summary }}</div>
             </a>
             <div class="issue-stats">


### PR DESCRIPTION
Adjusted the thread cards on the feed page to display state/location data. Copied the style that location information is displayed on the breadcrumbs when viewing at thread.