### PR TITLE
fix aloe tests

### DIFF
--- a/project/test_framework/__init__.py
+++ b/project/test_framework/__init__.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 
 from aloe import around, world
@@ -17,7 +18,8 @@ def with_chrome():
     options.add_argument('--headless')
     options.add_argument('--disable-extensions')
     options.add_argument("--no-sandbox")
-    world.browser = webdriver.Chrome(options=options)
+    driver_path = os.path.dirname(os.path.realpath(__file__)) + "/utilities/chromedriver.exe"
+    world.browser = webdriver.Chrome(executable_path=driver_path, options=options)
     yield
     world.browser.quit()
     delattr(world, 'browser')


### PR DESCRIPTION
@brylie it appears that during a refactoring the location of the chromedriver was lost. I added it in the project and is now working. In order to run the tests you should:
1. Install 'aloe'. It's already a part of the requirements.txt
2. Run the command 'aloe' inside the test_framework directory. Otherwise it will not find the feature files.
3. This PR adds the chromedriver executable again. If this location is not convenient for you you can move it to another place and edit the path in the __init__ file. Also, this instance is for Windows.
Google Chrome needs to be installed on the system you run the tests.
Some of the tests also fail but given it's being an year since I wrote them, this is to be expected.