### PR TITLE
Corrects comma usage/wording in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 # Welcome to Civiwiki!
 
-We are an open source, non-profit community, working to develop a democratic engagement web system.
+We are an open source, non-profit community working to develop a democratic engagement web system.
 
 ## Why CiviWiki?
 
-* **Democratically Contributed Media.** As the name CiviWiki implies, our core content will be contributed by volunteers on our Wiki. Our topic format is modular. The structure allows both a community of volunteers to collaborate on a single political issue, and reserves space for dissenting opinions.
-* **Personalized Policy Feed.** CiviWiki intelligently personalizes users' feed in two meaningful ways. First, the issues promoted to users' feed will be personalized to the user's expressed interests, and the timeliness of the issue. Second, the structure of the issue topics break policy positions into bite-sized contentions we call Civies. Each Civi is logically related to the rest of the topic. Based on the user's support, opposition, or neutrality to each Civi, CiviWiki promotes different relevant content.
-* **Citizen/Representative Engagement.** CiviWiki's core goal is to engage citizens and their representatives, with the goal of making government more accountable. CiviWiki will achieve this goal in two ways. First, CiviWiki will organize user's policy profile and compare it to every political candidate in the user's district. This quick, detailed, comparison will help users make informed votes, and we believe increased voter confidence will increase voter turnout. Second, CiviWiki will collect anonymized user data and forward district level statistics to representatives. With a critical mass of users, we believe timely district level polling data will influence representatives' votes.
+* **Democratically Contributed Media.** As the name CiviWiki implies, our core content will be contributed by volunteers on our Wiki. Our topic format is modular. The structure allows both a community of volunteers to collaborate on a single political issue and reserves space for dissenting opinions.
+* **Personalized Policy Feed.** CiviWiki intelligently personalizes users' feed in two meaningful ways. First, the issues promoted to users' feed will be personalized to the user's expressed interests and the timeliness of the issue. Second, the structure of the issue topics break policy positions into bite-sized contentions we call Civies. Each Civi is logically related to the rest of the topic. Based on the user's support, opposition, or neutrality to each Civi, CiviWiki promotes different relevant content.
+* **Citizen/Representative Engagement.** CiviWiki aims to engage citizens and their representatives, with the core goal of making government more accountable. CiviWiki will achieve this goal in two ways. First, CiviWiki will organize user's policy profile and compare it to every political candidate in the user's district. This quick, detailed comparison will help users make informed votes, and we believe increased voter confidence will increase voter turnout. Second, CiviWiki will collect anonymized user data and forward district level statistics to representatives. With a critical mass of users, we believe timely district level polling data will influence representatives' votes.
 
 # Contact info
 Contact us on Twitter to join the team:


### PR DESCRIPTION
There were some unnecessary commas in the explanation of CiviWiki and one awkward repetition of the world "goal" under Citizen/Representative Engagement.

The grammatically incorrect commas have been removed and the wording very slightly changed in the first sentence of Citizen/Representative Engagements.