### PR TITLE
Remove styles from "edit profile" tab

### DIFF
--- a/project/webapp/templates/partials/account/account_base.html
+++ b/project/webapp/templates/partials/account/account_base.html
@@ -15,8 +15,8 @@
                             <li class="tab"><a href="#mybills">MY BILLS</a></li>
                             <li class="tab"><a href="#myreps">MY REPS</a></li>
                             {% if request.user.username == username|stringformat:"s" %}
-                            <li class="tab settings-tab">
-                                <a class="btn" href="#settings" id="edit-profile"><i class="mini material-icons">edit</i>EDIT PROFILE</a>
+                            <li class="tab">
+                                <a href="#settings">EDIT PROFILE</a>
                             </li>
                             {% endif %}
                         </ul>


### PR DESCRIPTION
This makes the Edit Profile tab look like the other tabs, making the design more consistent and allowing for a clearer navigation experience.

- Solves issue #211
- Previous PR: #393 