### PR TITLE
Revert "Waffle.io was shutdown so it doesn't make sense keeping that link up:…"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![ComVer](https://img.shields.io/badge/ComVer-compliant-brightgreen.svg)](https://github.com/staltz/comver)
+[![Stories in Ready](https://badge.waffle.io/CiviWiki/OpenCiviWiki.png?label=next%20up&title=next%20tasks)](https://waffle.io/CiviWiki/OpenCiviWiki?utm_source=badge)
 [![Maintainability](https://api.codeclimate.com/v1/badges/5241b4275cc2dffe90f2/maintainability)](https://codeclimate.com/github/CiviWiki/OpenCiviWiki/maintainability)
 
 # Welcome to Civiwiki!


### PR DESCRIPTION
Reverts CiviWiki/OpenCiviWiki#777