### PR TITLE
Updates chatroom to discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Join us on the following channels:
 
 * [development discussions](https://www.loomio.org/g/ET40tXUC/openciviwiki) on Loomio
 * [videos of our weekly planning meetings](https://archive.org/search.php?query=subject%3A%22CiviWiki%22&sort=-date) on Internet Archive
-* [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org) on Matrix
-* [development roadmap](https://waffle.io/CiviWiki/OpenCiviWiki) on Waffle.io
+* [live chat](https://discord.gg/zkAe55bEkh) on Discord
 * [@CiviWiki](https://twitter.com/civiwiki) on Twitter
 
 # Contribute

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Make sure to search beforehand to see if the issue has been previously reported.
 
-The issue tracker should not be used for personal support requests. Please direct those to our [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org)
+The issue tracker should not be used for personal support requests. Please direct those to our [live chat](https://discord.gg/zkAe55bEkh)
 
 ## Bug Reports
 Please try to have as much detail as possible when creating a bug report.
@@ -22,7 +22,7 @@ A good example should contain:
 A good bug report will help direct developers to solve the problem at hand without wasting time trying to figure out the problem in the first place.
 
 ## Feature Requests/Enhancements
-If you have a budding idea or a feature that requires a more community-involved discussion, consider having the development discussion on the [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org) or create a thread on [loomio](https://www.loomio.org/g/ET40tXUC/openciviwiki). This will allow for a well-thought-out issue that will more likely be in line with the goal of the project.
+If you have a budding idea or a feature that requires a more community-involved discussion, consider having the development discussion on the [live chat](https://discord.gg/zkAe55bEkh) or create a thread on [loomio](https://www.loomio.org/g/ET40tXUC/openciviwiki). This will allow for a well-thought-out issue that will more likely be in line with the goal of the project.
 
 # Set-up instructions
 Use instruction from one of points below:

--- a/project/webapp/templates/static_templates/static_footer.html
+++ b/project/webapp/templates/static_templates/static_footer.html
@@ -31,7 +31,7 @@
                         <a class="grey-text text-darken-1" href="https://waffle.io/CiviWiki/OpenCiviWiki" target="_blank">Development Roadmap</a>
                     </div>
                     <div class="external-link-item">
-                        <a class="grey-text text-darken-1" href="https://riot.im/app/#/room/#CiviWiki:matrix.org" target="_blank">Live Chat on Matrix</a>
+                        <a class="grey-text text-darken-1" href="https://discord.gg/zkAe55bEkh" target="_blank">Live Chat on Matrix</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
I've noticed recently that we have low participation in our current Matrix chatroom and I'm wondering if it is related to the chat client being somewhat clunky and unfamiliar to people.

I've created a new chat server on Discord that I propose we switch over to. I think it is important to have a space where people can discuss features, the roadmap, and get help! I'm open to using any other well supported chat client like Slack if people have preferences.

This PR also deletes our waffle.io link since that site has been shut down.