### PR TITLE
Remove references to the defunct waffle.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Welcome to Civiwiki
 
 [![ComVer](https://img.shields.io/badge/ComVer-compliant-brightgreen.svg)](https://github.com/staltz/comver)
-[![Stories in Ready](https://badge.waffle.io/CiviWiki/OpenCiviWiki.png?label=next%20up&title=next%20tasks)](https://waffle.io/CiviWiki/OpenCiviWiki?utm_source=badge)
 [![Maintainability](https://api.codeclimate.com/v1/badges/5241b4275cc2dffe90f2/maintainability)](https://codeclimate.com/github/CiviWiki/OpenCiviWiki/maintainability)
 
 We are an open source, non-profit community, working to develop a democratic engagement web system.
@@ -37,7 +36,6 @@ Join us on the following channels:
 * [development discussions](https://www.loomio.org/g/ET40tXUC/openciviwiki) on Loomio
 * [videos of our weekly planning meetings](https://archive.org/search.php?query=subject%3A%22CiviWiki%22&sort=-date) on Internet Archive
 * [live chat](https://riot.im/app/#/room/#CiviWiki:matrix.org) on Matrix
-* [development roadmap](https://waffle.io/CiviWiki/OpenCiviWiki) on Waffle.io
 * [@CiviWiki](https://twitter.com/civiwiki) on Twitter
 
 # Contribute

--- a/project/webapp/templates/static_templates/static_footer.html
+++ b/project/webapp/templates/static_templates/static_footer.html
@@ -28,9 +28,6 @@
                         <a class="grey-text text-darken-1" href="https://github.com/CiviWiki/OpenCiviWiki/issues" target="_blank">Open Issues</a>
                     </div>
                     <div class="external-link-item">
-                        <a class="grey-text text-darken-1" href="https://waffle.io/CiviWiki/OpenCiviWiki" target="_blank">Development Roadmap</a>
-                    </div>
-                    <div class="external-link-item">
                         <a class="grey-text text-darken-1" href="https://riot.im/app/#/room/#CiviWiki:matrix.org" target="_blank">Live Chat on Matrix</a>
                     </div>
                 </div>


### PR DESCRIPTION
Closes #920. Removes references to `waffle.io` from both `README.md`, as well as the static footer for pages.