### PR TITLE
#939: Removed parameter from call to Djando `distinct` function b/c parameters invoke the SQL cmd DISTINCT ON and only PostgreSQL supports that cmd

### DIFF
--- a/project/api/read.py
+++ b/project/api/read.py
@@ -54,7 +54,8 @@ def get_profile(request, user):
         voted_solutions = Activity.objects.filter(
             account=a.id, civi__c_type="solution", activity_type__contains="pos"
         )
-        solution_threads = voted_solutions.distinct("thread__id").values_list(
+
+        solution_threads = voted_solutions.distinct().values_list(
             "thread__id", flat=True
         )
 
@@ -90,10 +91,16 @@ def get_profile(request, user):
                 result["follow_state"] = True
             else:
                 result["follow_state"] = False
+
+        print(result)
         return JsonResponse(result)
 
     except Account.DoesNotExist as e:
         return HttpResponseBadRequest(reason=str(e))
+
+    except Exception as e:
+        print('HEY! HEY!')
+        return(e)
 
 
 def get_feed(request):

--- a/project/api/read.py
+++ b/project/api/read.py
@@ -55,9 +55,11 @@ def get_profile(request, user):
             account=a.id, civi__c_type="solution", activity_type__contains="pos"
         )
 
-        solution_threads = voted_solutions.distinct().values_list(
-            "thread__id", flat=True
-        )
+        # solution_threads = voted_solutions.distinct().values_list(
+        #     "thread__id", flat=True
+        # )
+
+        solution_threads = voted_solutions.values("thread__id").distinct()
 
         for thread_id in solution_threads:
             t = Thread.objects.get(id=thread_id)

--- a/project/api/read.py
+++ b/project/api/read.py
@@ -55,10 +55,6 @@ def get_profile(request, user):
             account=a.id, civi__c_type="solution", activity_type__contains="pos"
         )
 
-        # solution_threads = voted_solutions.distinct().values_list(
-        #     "thread__id", flat=True
-        # )
-
         solution_threads = voted_solutions.values("thread__id").distinct()
 
         for thread_id in solution_threads:

--- a/project/api/read.py
+++ b/project/api/read.py
@@ -92,15 +92,10 @@ def get_profile(request, user):
             else:
                 result["follow_state"] = False
 
-        print(result)
         return JsonResponse(result)
 
     except Account.DoesNotExist as e:
         return HttpResponseBadRequest(reason=str(e))
-
-    except Exception as e:
-        print('HEY! HEY!')
-        return(e)
 
 
 def get_feed(request):

--- a/project/api/serializers.py
+++ b/project/api/serializers.py
@@ -333,7 +333,7 @@ class ThreadDetailSerializer(serializers.ModelSerializer):
         """This function gets the list of contributors for Civiwiki"""
         issue_civis = Civi.objects.filter(thread__id=obj.id)
         contributor_accounts = Account.objects.filter(
-            pk__in=issue_civis.distinct("author").values_list("author", flat=True)
+            pk__in=issue_civis.values("author").distinct()
         )
         return AccountListSerializer(contributor_accounts, many=True).data
 

--- a/project/api/write.py
+++ b/project/api/write.py
@@ -114,7 +114,7 @@ def createCivi(request):
         else:  # not a reply, a regular civi
             c_qs = Civi.objects.filter(thread_id=thread_id)
             accounts = Account.objects.filter(
-                pk__in=c_qs.distinct("author").values_list("author", flat=True)
+                pk__in=c_qs.values("author").distinct()
             )
             data = {
                 "command": "add",
@@ -325,9 +325,10 @@ def editUser(request):
     try:
         account.save()
     except Exception as e:
+        # print('EXCEPTION THROWN HERE!! ')
         return HttpResponseServerError(reason=str(e))
 
-    account.refresh_from_db()
+        account.refresh_from_db()
 
     return JsonResponse(Account.objects.summarize(account))
 

--- a/project/frontend_views/views.py
+++ b/project/frontend_views/views.py
@@ -121,7 +121,7 @@ def issue_thread(request, thread_id=None):
         "contributors": [
             Account.objects.chip_summarize(a)
             for a in Account.objects.filter(
-                pk__in=c_qs.distinct("author").values_list("author", flat=True)
+                pk__in=c_qs.values("author").distinct()
             )
         ],
         "category": {"id": t.category.id, "name": t.category.name},


### PR DESCRIPTION
Closes #939

The bug happens when the settings page tries to read a user's account info from the database. It uses Django's `distinct` function. If the `distinct` function is used with parameters, then it will invoke the SQL command DISTINCT ON which is only supported by PostgreSQL. @deepspaceghost figured this out while we were pair programming.

We haven't gotten a chance to fully regression test the fix. The DISTINCT ON command might have been used for a reason, and without it something else might be broken. There are also a lot of other similar calls to Django's distinct function that could be causing similar errors.