### PR TITLE
Restructure project

### DIFF
--- a/project/accounts/forms.py
+++ b/project/accounts/forms.py
@@ -206,14 +206,14 @@ class RecoverUserForm(AuthRecoverUserForm):
             )
 
 
-class UpdateProfile(forms.ModelForm):
+class ProfileEditForm(forms.ModelForm):
     """
     Form for updating Profile data
     """
 
     def __init__(self, *args, **kwargs):
         readonly = kwargs.pop("readonly", False)
-        super(UpdateProfile, self).__init__(*args, **kwargs)
+        super(ProfileEditForm, self).__init__(*args, **kwargs)
         if readonly:
             self.disable_fields()
 

--- a/project/accounts/templates/accounts/users/password_reset_email.html
+++ b/project/accounts/templates/accounts/users/password_reset_email.html
@@ -1,7 +1,7 @@
 {% autoescape off %}
 To initiate the password reset process for your OpenCiviWiki Account, click the link below:
 
-{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'accounts_password_reset_confirm' uidb64=uid token=token %}
 
 If clicking the link above doesn't work, please copy and paste the URL in a new browser
 window instead.

--- a/project/accounts/templates/accounts/users/password_reset_subject.txt
+++ b/project/accounts/templates/accounts/users/password_reset_subject.txt
@@ -2,7 +2,7 @@
 To initiate the password reset process for your {{ user.get_username }} OpenCiviWiki Account,
 click the link below:
 
-{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'accounts_password_reset_confirm' uidb64=uid token=token %}
 
 If clicking the link above doesn't work, please copy and paste the URL in a new browser
 window instead.

--- a/project/accounts/urls.py
+++ b/project/accounts/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 from django.urls import path
 from django.contrib.auth import views as auth_views
-from accounts.views import RegisterView
+from accounts.views import RegisterView, SettingsView, ProfileActivationView
 from . import authentication
 
 urlpatterns = [
@@ -12,11 +12,8 @@ urlpatterns = [
     ),
     path('logout/', auth_views.LogoutView.as_view(), name='accounts_logout'),
     path('register/', RegisterView.as_view(), name='accounts_register'),
-    url(
-        r"^activate_account/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$",
-        authentication.activate_view,
-        name="activate_account",
-    ),
+    path('settings/', SettingsView.as_view(), name='accounts_settings'),
+    path('activate_account/<uidb64>/<token>/', ProfileActivationView.as_view(), name='accounts_activate'),
     url(
         r"^forgot/$",
         auth_views.PasswordResetView.as_view(),

--- a/project/accounts/views.py
+++ b/project/accounts/views.py
@@ -21,7 +21,7 @@ from django.contrib.auth import get_user_model
 from accounts.models import Profile
 from core.custom_decorators import login_required
 
-from accounts.forms import UserRegistrationForm, UpdateProfile
+from accounts.forms import UserRegistrationForm, ProfileEditForm
 
 from .authentication import send_activation_email
 

--- a/project/accounts/views.py
+++ b/project/accounts/views.py
@@ -12,10 +12,8 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth import login
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.contrib.sites.shortcuts import get_current_site
-from django.utils.encoding import force_bytes
 from django.utils.http import int_to_base36
 from django.utils.crypto import salted_hmac
-from django.utils.http import urlsafe_base64_encode
 from django.urls import reverse_lazy
 from django.contrib.auth import get_user_model
 from django.utils.encoding import force_str
@@ -26,7 +24,7 @@ from accounts.models import Profile
 
 from accounts.forms import UserRegistrationForm, ProfileEditForm
 
-from .authentication import send_activation_email
+from accounts.authentication import send_activation_email, account_activation_token
 
 
 class ProfileActivationTokenGenerator(PasswordResetTokenGenerator):
@@ -38,10 +36,8 @@ class ProfileActivationTokenGenerator(PasswordResetTokenGenerator):
         """Token function pulled from Django 1.11"""
         ts_b36 = int_to_base36(timestamp)
 
-        hash = salted_hmac(self.key_salt, str(user.pk) + str(timestamp)).hexdigest()[
-            ::2
-        ]
-        return "%s-%s" % (ts_b36, hash)
+        hash_string = salted_hmac(self.key_salt, str(user.pk) + str(timestamp)).hexdigest()[::2]
+        return "%s-%s" % (ts_b36, hash_string)
 
 
 class RegisterView(FormView):

--- a/project/core/urls.py
+++ b/project/core/urls.py
@@ -23,7 +23,7 @@ from django.views.generic.base import RedirectView
 
 from api import urls as api
 from accounts.views import (PasswordResetView, PasswordResetDoneView,
-                            PasswordResetConfirmView, PasswordResetCompleteView, settings_view)
+                            PasswordResetConfirmView, PasswordResetCompleteView)
 from frontend_views import urls as frontend_views
 
 

--- a/project/core/urls.py
+++ b/project/core/urls.py
@@ -32,24 +32,24 @@ urlpatterns = [
     path("", include('accounts.urls')),
     url(r"^api/", include(api)),
     path(
-        'accounts/password_reset',
+        'accounts/password_reset/',
         PasswordResetView.as_view(),
         name='accounts_password_reset',
     ),
 
     path(
-        'accounts/password_reset_done',
+        'accounts/password_reset_done/',
         PasswordResetDoneView.as_view(),
         name='accounts_password_reset_done',
     ),
     path(
-        'accounts/password_reset_confirm/<uidb64>/<token>',
+        'accounts/password_reset_confirm/<uidb64>/<token>/',
         PasswordResetConfirmView.as_view(),
         name='accounts_password_reset_confirm',
     ),
 
     path(
-        'accounts/password_reset_complete',
+        'accounts/password_reset_complete/',
         PasswordResetCompleteView.as_view(),
         name='accounts_password_reset_complete',
     ),

--- a/project/core/urls.py
+++ b/project/core/urls.py
@@ -53,7 +53,6 @@ urlpatterns = [
         PasswordResetCompleteView.as_view(),
         name='accounts_password_reset_complete',
     ),
-    url(r"^settings$", settings_view, name="settings"),
     url(
         "^inbox/notifications/",
         include("notifications.urls", namespace="notifications"),

--- a/project/frontend_views/views.py
+++ b/project/frontend_views/views.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 
 from api.models import Category, Thread, Civi, Activity
 from accounts.models import Profile
-from accounts.forms import UpdateProfile
+from accounts.forms import ProfileEditForm
 from api.forms import UpdateProfileImage
 from core.constants import US_STATES
 from core.custom_decorators import login_required, full_profile
@@ -73,7 +73,7 @@ def user_profile(request, username=None):
             except User.DoesNotExist:
                 return HttpResponseRedirect("/404")
 
-        form = UpdateProfile(
+        form = ProfileEditForm(
             initial={
                 "username": user.username,
                 "email": user.email,


### PR DESCRIPTION
Improving Issue #952 and Issue #1004 

As discussed in #1004, I renamed `UpdateProfile` to `ProfileEditForm`.
I updated `SettingsView` and `ProfileActivationView` so that they are not FBV anymore.

I realized that the activation link in the email is broken There is also another bug: If activation mail is manually changed then an error rises so the project is broken due to the exception I fixed both of them. 

I added unit tests for `SettingsView` and `ProfileActivationView` to improve test coverage. I personally tested these views to be sure that they work well. Seemingly, everything is perfect.