### PR TITLE
Create base template and extend it to templates in core/templates folder

### DIFF
--- a/project/core/templates/about.html
+++ b/project/core/templates/about.html
@@ -1,14 +1,14 @@
-﻿<!DOCTYPE HTML>
-<!-- About -->
-<head>
-    {% load static %}
-    {% load i18n %}
-    {% include "base/links.html" %}
-    <link type="text/css" rel="stylesheet/less" href="{% static "less/about.less" %}"/>
-    <script src="{% static "dependencies/less.min.js" type="text/javascript" %}"></script>
-    <title>{% trans "About Us" %}</title>
-</head>
+﻿{% extends "base.html" %}
+{% load static %}
+{% load i18n %}
 
+{% block extra_css %}
+<link type="text/css" rel="stylesheet/less" href="{% static "less/about.less" %}"/>
+{% endblock extra_css %}
+    
+{% block page_title %}{% trans "About Us" %}{% endblock page_title %}
+
+{% block backbone_template %}
 <script id="about-template" type="text/template">
 <header>
     <div class="content-header center">
@@ -185,15 +185,18 @@
     </div>
     </main>
 </script>
+{% endblock backbone_template %}
 
-<body>
+{% block content %}
     {% include "static_nav.html" %}
     <div id="about"></div>
     {% include "static_footer.html" %}
-</body>
+{% endblock content %}
 
+{% block extra_js %}
 <!-- Backbone Views File -->
 <script src="{% static "js/static/about_view.js" %}" type="text/javascript"></script>
 <script type="text/javascript">
     var aboutView = new cw.AboutView();
 </script>
+{% endblock extra_js %}

--- a/project/core/templates/about.html
+++ b/project/core/templates/about.html
@@ -3,7 +3,8 @@
 {% load i18n %}
 
 {% block extra_css %}
-<link type="text/css" rel="stylesheet/less" href="{% static "less/about.less" %}"/>
+    <link type="text/css" rel="stylesheet/less" href="{% static "less/about.less" %}"/>
+    <script src="{% static "dependencies/less.min.js" type="text/javascript" %}"></script>
 {% endblock extra_css %}
     
 {% block page_title %}{% trans "About Us" %}{% endblock page_title %}

--- a/project/core/templates/about.html
+++ b/project/core/templates/about.html
@@ -189,9 +189,7 @@
 {% endblock backbone_template %}
 
 {% block content %}
-    {% include "static_nav.html" %}
     <div id="about"></div>
-    {% include "static_footer.html" %}
 {% endblock content %}
 
 {% block extra_js %}

--- a/project/core/templates/base.html
+++ b/project/core/templates/base.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load static %}
-<!DOCTYPE html>
+<!DOCTYPE HTML>
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -32,7 +32,9 @@
 {% block backbone_template %}{% endblock backbone_template %}
 
 <body class="{% block body_class %}{% endblock body_class %}" id="{% block body_id %}{% endblock body_id %}">
+    {% include "static_nav.html" %}
     {% block content %}{% endblock content %}
+    {% include "static_footer.html" %}
 
     {% block extra_js %}{% endblock extra_js %}
 </body>

--- a/project/core/templates/base.html
+++ b/project/core/templates/base.html
@@ -33,7 +33,11 @@
 
 <body class="{% block body_class %}{% endblock body_class %}" id="{% block body_id %}{% endblock body_id %}">
     {% include "static_nav.html" %}
+    {% include "static_nav.html" %}
+    
     {% block content %}{% endblock content %}
+    
+    {% include "static_footer.html" %}
     {% include "static_footer.html" %}
 
     {% block extra_js %}{% endblock extra_js %}

--- a/project/core/templates/base.html
+++ b/project/core/templates/base.html
@@ -15,17 +15,16 @@
 	<link rel="shortcut icon" href="/favicon.ico">
 	<meta name="msapplication-TileImage" content="/mstile-144x144.png">
 	<meta name="msapplication-TileColor" content="#fcffff"> 
-	<link type="text/css" rel="stylesheet" href="{% static "dependencies/materialize.min.css" %}">
-	<link type="text/css" rel="stylesheet" href="{% static "dependencies/magicsuggest-min.css" %}">
-	<script type="text/javascript" src="{% static "dependencies/jquery.min.js" %}"></script>
-	<script type="text/javascript" src="{% static "dependencies/underscore.js" %}"></script>
-	<script type="text/javascript" src="{% static "dependencies/backbone-min.js" %}"></script>
-	<script type="text/javascript" src="{% static "dependencies/materialize.min.js" %}"></script>
-	<script type="text/javascript" src="{% static "dependencies/magicsuggest-min.js" %}"></script>
-	<script type="text/javascript" src="{% static "js/base.js" %}"></script>
-	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
-    <script src="{% static "dependencies/less.min.js" type="text/javascript" %}"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+    <link type="text/css" rel="stylesheet" href="{% static "dependencies/magicsuggest-min.css" %}">
+    <script type="text/javascript" src="{% static "dependencies/jquery.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "dependencies/underscore.js" %}"></script>
+    <script type="text/javascript" src="{% static "dependencies/backbone-min.js" %}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script type="text/javascript" src="{% static "dependencies/magicsuggest-min.js" %}"></script>
+    <script type="text/javascript" src="{% static "js/base.js" %}"></script>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   
     {% block extra_css %}{% endblock extra_css %}
 </head>

--- a/project/core/templates/base.html
+++ b/project/core/templates/base.html
@@ -7,7 +7,7 @@
     <title>CiviWiki - {% block page_title %}{% endblock page_title %}</title>
     <meta name="description" content="Building a Better Democracy for the Internet Age">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    
+	
 	<link href="https://fonts.googleapis.com/css?family=Lato:300,400,600,700" rel="stylesheet">
 
 	<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -15,17 +15,17 @@
 	<link rel="shortcut icon" href="/favicon.ico">
 	<meta name="msapplication-TileImage" content="/mstile-144x144.png">
 	<meta name="msapplication-TileColor" content="#fcffff"> 
-	<link type="text/css" rel="stylesheet" href="{% static 'dependencies/materialize.min.css' %}">
-	<link type="text/css" rel="stylesheet" href="{% static 'dependencies/magicsuggest-min.css' %}">
-	<script type="text/javascript" src="{% static 'dependencies/jquery.min.js' %}"></script>
-	<script type="text/javascript" src="{% static 'dependencies/underscore.js' %}"></script>
-	<script type="text/javascript" src="{% static 'dependencies/backbone-min.js' %}"></script>
-	<script type="text/javascript" src="{% static 'dependencies/materialize.min.js' %}"></script>
-	<script type="text/javascript" src="{% static 'dependencies/magicsuggest-min.js' %}"></script>
-	<script type="text/javascript" src="{% static 'js/base.js' %}"></script>
+	<link type="text/css" rel="stylesheet" href="{% static "dependencies/materialize.min.css" %}">
+	<link type="text/css" rel="stylesheet" href="{% static "dependencies/magicsuggest-min.css" %}">
+	<script type="text/javascript" src="{% static "dependencies/jquery.min.js" %}"></script>
+	<script type="text/javascript" src="{% static "dependencies/underscore.js" %}"></script>
+	<script type="text/javascript" src="{% static "dependencies/backbone-min.js" %}"></script>
+	<script type="text/javascript" src="{% static "dependencies/materialize.min.js" %}"></script>
+	<script type="text/javascript" src="{% static "dependencies/magicsuggest-min.js" %}"></script>
+	<script type="text/javascript" src="{% static "js/base.js" %}"></script>
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
-    <script src="{% static 'dependencies/less.min.js' type='text/javascript' %}"></script>
+    <script src="{% static "dependencies/less.min.js" type="text/javascript" %}"></script>
   
     {% block extra_css %}{% endblock extra_css %}
 </head>

--- a/project/core/templates/base.html
+++ b/project/core/templates/base.html
@@ -1,0 +1,40 @@
+{% load i18n %}
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>CiviWiki - {% block page_title %}{% endblock page_title %}</title>
+    <meta name="description" content="Building a Better Democracy for the Internet Age">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    
+	<link href="https://fonts.googleapis.com/css?family=Lato:300,400,600,700" rel="stylesheet">
+
+	<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+	<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+	<link rel="shortcut icon" href="/favicon.ico">
+	<meta name="msapplication-TileImage" content="/mstile-144x144.png">
+	<meta name="msapplication-TileColor" content="#fcffff"> 
+	<link type="text/css" rel="stylesheet" href="{% static 'dependencies/materialize.min.css' %}">
+	<link type="text/css" rel="stylesheet" href="{% static 'dependencies/magicsuggest-min.css' %}">
+	<script type="text/javascript" src="{% static 'dependencies/jquery.min.js' %}"></script>
+	<script type="text/javascript" src="{% static 'dependencies/underscore.js' %}"></script>
+	<script type="text/javascript" src="{% static 'dependencies/backbone-min.js' %}"></script>
+	<script type="text/javascript" src="{% static 'dependencies/materialize.min.js' %}"></script>
+	<script type="text/javascript" src="{% static 'dependencies/magicsuggest-min.js' %}"></script>
+	<script type="text/javascript" src="{% static 'js/base.js' %}"></script>
+	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+    <script src="{% static 'dependencies/less.min.js' type='text/javascript' %}"></script>
+  
+    {% block extra_css %}{% endblock extra_css %}
+</head>
+
+{% block backbone_template %}{% endblock backbone_template %}
+
+<body class="{% block body_class %}{% endblock body_class %}" id="{% block body_id %}{% endblock body_id %}">
+    {% block content %}{% endblock content %}
+
+    {% block extra_js %}{% endblock extra_js %}
+</body>
+</html>

--- a/project/core/templates/base.html
+++ b/project/core/templates/base.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load static %}
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">

--- a/project/core/templates/base.html
+++ b/project/core/templates/base.html
@@ -33,11 +33,9 @@
 
 <body class="{% block body_class %}{% endblock body_class %}" id="{% block body_id %}{% endblock body_id %}">
     {% include "static_nav.html" %}
-    {% include "static_nav.html" %}
     
     {% block content %}{% endblock content %}
     
-    {% include "static_footer.html" %}
     {% include "static_footer.html" %}
 
     {% block extra_js %}{% endblock extra_js %}

--- a/project/core/templates/how_it_works.html
+++ b/project/core/templates/how_it_works.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
-<!-- How it Works -->
 {% load static %}
 {% load i18n %}
 
+<!-- How it Works -->
 {% block extra_css %}
     <link type="text/css" rel="stylesheet/less" href="{% static "less/how_it_works.less" %}"/>
+    <script src="{% static "dependencies/less.min.js" type="text/javascript" %}"></script>
 {% endblock extra_css %}
 
 {% block backbone_template %}
@@ -44,7 +45,7 @@
     {% include "static_nav.html" %}
     <div id="howitworks"></div>
     {% include "static_footer.html" %}
-{% endblock backbone_template %}
+{% endblock content %}
 
 {% block extra_js %}
 <!-- Backbone Views File -->

--- a/project/core/templates/how_it_works.html
+++ b/project/core/templates/how_it_works.html
@@ -42,9 +42,7 @@
 {% endblock backbone_template %}
 
 {% block content %}
-    {% include "static_nav.html" %}
     <div id="howitworks"></div>
-    {% include "static_footer.html" %}
 {% endblock content %}
 
 {% block extra_js %}

--- a/project/core/templates/how_it_works.html
+++ b/project/core/templates/how_it_works.html
@@ -1,15 +1,13 @@
-<!DOCTYPE HTML>
+{% extends "base.html" %}
 <!-- How it Works -->
-<head>
-    {% load static %}
-    {% include "base/links.html" %}
-    {% load i18n %}
+{% load static %}
+{% load i18n %}
+
+{% block extra_css %}
     <link type="text/css" rel="stylesheet/less" href="{% static "less/how_it_works.less" %}"/>
-    <script src="{% static "dependencies/less.min.js" type="text/javascript" %}"></script>
-</head>
+{% endblock extra_css %}
 
-<title>CiviWiki</title>
-
+{% block backbone_template %}
 <script id="howitworks-template" type="text/template">
     <div class="content-header center">
         <div class="container section">
@@ -40,15 +38,18 @@
         </div>
     </div>
 </script>
+{% endblock backbone_template %}
 
-<body>
+{% block content %}
     {% include "static_nav.html" %}
     <div id="howitworks"></div>
     {% include "static_footer.html" %}
-</body>
+{% endblock backbone_template %}
 
+{% block extra_js %}
 <!-- Backbone Views File -->
 <script src="{% static "js/static/how_it_works_view.js" %}" type="text/javascript"></script>
 <script type="text/javascript">
     var howitworksView = new cw.HowItWorksView();
 </script>
+{% endblock extra_js %}

--- a/project/core/templates/landing.html
+++ b/project/core/templates/landing.html
@@ -1,16 +1,13 @@
-<!DOCTYPE HTML>
+{% extends "base.html" %}
 <!-- Landing Page -->
-<html>
-<head>
-    {% load static %}
-    {% load i18n %}
-    {% include "base/links.html" %}
+{% load static %}
+{% load i18n %}    
+
+{% block extra_css %}
     <link type="text/css" rel="stylesheet/less" href="{% static "less/landing.less" %}"/>
-    <script src="{% static "dependencies/less.min.js" %}" type="text/javascript"></script>
-</head>
+{% endblock extra_css %}
 
-<title>CiviWiki</title>
-
+{% block backbone_template %}
 <script id="landing-template" type="text/template">
 <header>
     <div class="landing-bg valign-wrapper full-height">
@@ -159,16 +156,18 @@
 </main>
 
 </script>
+{% endblock backbone_template %}
 
-<body>
+{% block content %}
     {% include "static_nav.html" %}
     <div id="landing"></div>
     {% include "static_footer.html" %}
-</body>
+{% endblock content %}
 
+{% block extra_js %}
 <!-- Backbone Views File -->
 <script src="{% static "js/static/landing_view.js" %}" type="text/javascript"></script>
 <script type="text/javascript">
     var landingView = new cw.LandingView();
 </script>
-</html>
+{% endblock extra_js %}

--- a/project/core/templates/landing.html
+++ b/project/core/templates/landing.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
-<!-- Landing Page -->
 {% load static %}
 {% load i18n %}    
 
+<!-- Landing Page -->
 {% block extra_css %}
     <link type="text/css" rel="stylesheet/less" href="{% static "less/landing.less" %}"/>
+    <script src="{% static "dependencies/less.min.js" type="text/javascript" %}"></script>
 {% endblock extra_css %}
 
 {% block backbone_template %}

--- a/project/core/templates/landing.html
+++ b/project/core/templates/landing.html
@@ -160,9 +160,7 @@
 {% endblock backbone_template %}
 
 {% block content %}
-    {% include "static_nav.html" %}
     <div id="landing"></div>
-    {% include "static_footer.html" %}
 {% endblock content %}
 
 {% block extra_js %}

--- a/project/core/templates/support_us.html
+++ b/project/core/templates/support_us.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
-<!-- Support Us -->
 {% load static %}
 {% load i18n %}
 
+<!-- Support Us -->
 {% block extra_css %}
     <link type="text/css" rel="stylesheet/less" href="{% static "less/supportus.less" %}"/>
+    <script src="{% static "dependencies/less.min.js" type="text/javascript" %}"></script>
 {% endblock extra_css %}
 
 {% block page_title %}{% trans "Support Us" %}{% endblock page_title %}

--- a/project/core/templates/support_us.html
+++ b/project/core/templates/support_us.html
@@ -126,9 +126,7 @@
 {% endblock backbone_template %}
 
 {% block content %}
-    {% include "static_nav.html" %}
     <div id="supportus"></div>
-    {% include "static_footer.html" %}
 {% endblock content %}
 
 {% block extra_js %}

--- a/project/core/templates/support_us.html
+++ b/project/core/templates/support_us.html
@@ -1,16 +1,15 @@
-<!DOCTYPE HTML>
+{% extends "base.html" %}
 <!-- Support Us -->
-<html>
-<head>
-    {% load static %}
-    {% load i18n %}
-    {% include "base/links.html" %}
+{% load static %}
+{% load i18n %}
+
+{% block extra_css %}
     <link type="text/css" rel="stylesheet/less" href="{% static "less/supportus.less" %}"/>
-    <script src="{% static "dependencies/less.min.js" type="text/javascript" %}"></script>
-</head>
+{% endblock extra_css %}
 
-<title>{% trans "Support Us" %} </title>
+{% block page_title %}{% trans "Support Us" %}{% endblock page_title %}
 
+{% block backbone_template %}
 <script id="supportus-template" type="text/template">
     <!-- Main Picture and title using Parallax -->
     <div class="parallax-container">
@@ -123,13 +122,15 @@
     </div>
 
 </script>
+{% endblock backbone_template %}
 
-<body>
+{% block content %}
     {% include "static_nav.html" %}
     <div id="supportus"></div>
     {% include "static_footer.html" %}
-</body>
+{% endblock content %}
 
+{% block extra_js %}
 <!-- Backbone Views File -->
 <script src="{% static "js/static/support_us_view.js" %}" type="text/javascript"></script>
 <script type="text/javascript">
@@ -139,4 +140,4 @@
 
 });
 </script>
-</html>
+{% endblock extra_js %}


### PR DESCRIPTION
Close #1049 
- addresses first part of issue #1049 
- added a new file `core/templates/base.html` with boilerplate HTML to serve as the project's base template 
- edited 4 files in `core/templates` (`about.html`, `how_it_works.html`, `support_us.html`, `landing.html`) to be child templates of `base.html` 
- Modified child templates by removing `<doctype html>`, `<html>`, `<head>` and `<body>` markup, and putting remaining content inside the relevant blocks
- removed CiviWiki from the title of child templates when present (in `how_it_works.html` and `landing.html`) 