### PR TITLE
Fix JS links (Closes #1153)

### DIFF
--- a/project/core/templates/base.html
+++ b/project/core/templates/base.html
@@ -18,18 +18,19 @@
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/magicsuggest/2.1.5/magicsuggest-min.css" integrity="sha512-GSJWiGBeg4y85t66huKij+Oev1gKtVLfi/LKSZSyaSfPrNJORYM1lZkk94kpVtWAmDjYGDsxtLlHuFUtgVKBlQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/magicsuggest/2.1.5/magicsuggest-min.js" integrity="sha512-0qwHzv41cwsUdBjAxZb4g2U26gD3I0nbfwsM9loIDabYtspTH5XOaKpmOv/M9GQG3CCWjQvv4biWWZK7tcnDJA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/magic/1.1.0/magic.min.css" integrity="sha512-5KJYgPF7pe0cdJAg/9X6UdHE5cN9fqjjIi8ASyIqlcsKZdHVouNRcweLGEdtrIJJxMn+GqwJBjAurCjWOvEdJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/magicsuggest/2.1.5/magicsuggest-min.js" integrity="sha512-0qwHzv41cwsUdBjAxZb4g2U26gD3I0nbfwsM9loIDabYtspTH5XOaKpmOv/M9GQG3CCWjQvv4biWWZK7tcnDJA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.1/underscore-min.js" integrity="sha512-ZuOjyqq409+q6uc49UiBF3fTeyRyP8Qs0Jf/7FxH5LfhqBMzrR5cwbpDA4BgzSo884w6q/+oNdIeHenOqhISGw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.4.0/backbone-min.js" integrity="sha512-9EgQDzuYx8wJBppM4hcxK8iXc5a1rFLp/Chug4kIcSWRDEgjMiClF8Y3Ja9/0t8RDDg19IfY5rs6zaPS9eaEBw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/4.1.2/less.min.js" integrity="sha512-eXBn7AaMbUOWb3PSDhwcjByoM89FeO1SF9Jww6kqPYQkBrGZvqAKFbtqLHh5O95rYA/AOtWZ0QRO2S6rP+KsUw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script type="text/javascript" src="{% static "js/base.js" %}"></script>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" integrity="sha512-c42qTSw/wPZ3/5LBzD+Bw5f7bSF2oxou6wEb+I/lqeaKV5FDIfMvvRp772y4jcJLKuGUOpbJMdg/BTl50fJYAw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   
     {% block extra_css %}{% endblock extra_css %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/2.5.1/less.min.js" integrity="sha512-0YpTMMSmmT3qN4UJF5ZLv5MPiwBMlOOHrIVgdBMGyNiEKoPEMGyih0WkHOEozdl0qDa5cgFEVoteWbI3Ybsxmw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
 </head>
 
 {% block backbone_template %}{% endblock backbone_template %}


### PR DESCRIPTION
Closes #1153

PR #1156 has some issues. 

The landing page seems such that:

<img width="1440" alt="Screen Shot 2021-10-20 at 20 00 45" src="https://user-images.githubusercontent.com/16780927/138139915-19a7b2b4-20ba-4d98-a350-1cea9bb914e2.png">

The error is caused by

```
<script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/2.5.1/less.min.js" integrity="sha5120YpTMMSmmT3qN4UJF5ZLv5MPiwBMlOOHrIVgdBMGyNiEKoPEMGyih0WkHOEozdl0qDa5cgFEVotebI3Ybsxmw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
{% block extra_css %}{% endblock extra_css %}
```

`less.js` works only when the related `less` file is loaded. So I replace their order such that:

```
{% block extra_css %}{% endblock extra_css %}
<script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/2.5.1/less.min.js" integrity="sha5120YpTMMSmmT3qN4UJF5ZLv5MPiwBMlOOHrIVgdBMGyNiEKoPEMGyih0WkHOEozdl0qDa5cgFEVotebI3Ybsxmw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
```
This fixes this problem.

There is another issue:
```
magicsuggest-min.js:1 Uncaught ReferenceError: jQuery is not defined
    at magicsuggest-min.js:1
```

In order to fix this, I put jquery on the top of JS scripts.


Now the landing page is:
<img width="1433" alt="Screen Shot 2021-10-20 at 20 18 17" src="https://user-images.githubusercontent.com/16780927/138140712-5c6b3be2-7b9d-47d2-b48d-6378fa1a2c26.png">
