### PR TITLE
Change materialize framework version (Closes #1080)

### DIFF
--- a/project/core/templates/base.html
+++ b/project/core/templates/base.html
@@ -16,14 +16,14 @@
 	<meta name="msapplication-TileImage" content="/mstile-144x144.png">
 	<meta name="msapplication-TileColor" content="#fcffff"> 
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.6/css/materialize.min.css" integrity="sha512-moROQriAiFi6JByoXJdHeC9dXOiApe4Z+VYcZ6YbpTGekWRt6qn20JNgSpNEZDHiAcO0wHMLa3wkw4ue2Idp5A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/magicsuggest/2.1.5/magicsuggest-min.css" integrity="sha512-GSJWiGBeg4y85t66huKij+Oev1gKtVLfi/LKSZSyaSfPrNJORYM1lZkk94kpVtWAmDjYGDsxtLlHuFUtgVKBlQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/magic/1.1.0/magic.min.css" integrity="sha512-5KJYgPF7pe0cdJAg/9X6UdHE5cN9fqjjIi8ASyIqlcsKZdHVouNRcweLGEdtrIJJxMn+GqwJBjAurCjWOvEdJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/magicsuggest/2.1.5/magicsuggest-min.js" integrity="sha512-0qwHzv41cwsUdBjAxZb4g2U26gD3I0nbfwsM9loIDabYtspTH5XOaKpmOv/M9GQG3CCWjQvv4biWWZK7tcnDJA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.1/underscore-min.js" integrity="sha512-ZuOjyqq409+q6uc49UiBF3fTeyRyP8Qs0Jf/7FxH5LfhqBMzrR5cwbpDA4BgzSo884w6q/+oNdIeHenOqhISGw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.4.0/backbone-min.js" integrity="sha512-9EgQDzuYx8wJBppM4hcxK8iXc5a1rFLp/Chug4kIcSWRDEgjMiClF8Y3Ja9/0t8RDDg19IfY5rs6zaPS9eaEBw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.6/js/materialize.min.js" integrity="sha512-Va0Aw7JCo0ESFBs/A3NO+4CFo2wEdbuqlOtzl3MDlDGg6+8E3sHaOu2pZeLlEUHXYdm376MVU6lS8GzFC9EHeA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script type="text/javascript" src="{% static "js/base.js" %}"></script>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" integrity="sha512-c42qTSw/wPZ3/5LBzD+Bw5f7bSF2oxou6wEb+I/lqeaKV5FDIfMvvRp772y4jcJLKuGUOpbJMdg/BTl50fJYAw==" crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/project/core/templates/static/js/base.js
+++ b/project/core/templates/static/js/base.js
@@ -19,9 +19,11 @@ cw.checkForEnter = function (e) {
 };
 
 cw.materializeShit = function () {
+   $(document).ready(function() {
     Materialize.updateTextFields();
     $('ul.tabs').tabs();
     $('select').material_select();
+  });
 };
 
 cw.initGlobalNav = function () {


### PR DESCRIPTION
Closes #1080

I detect two issues that cause this problem:

1. I look at the `dependencies` folder that we've recently removed and I find versions of `materialize` js and css are `0.97.6` so I downgrade the versions. We get error when calling `Materialize.updateTextFields();` in `base.js`. In the newer versions, this is changed as  `M.updateTextFields();`. 

2. Since we get JS and CSS files via CDN, downloading static files takes more time than loading from local `dependencies` folder.  So I add `$(document).ready(function() {});` to the place where `materialize` is first called in `base.js`.

To fix the problem, these two changes are required, only one of them is not sufficient.

I should add that I spent a couple of hours solving this problem. 😋 