### PR TITLE
Fix API routes (Closes #1066)

### DIFF
--- a/project/accounts/urls/api.py
+++ b/project/accounts/urls/api.py
@@ -1,9 +1,5 @@
 from django.urls import path
-from core.router import CiviWikiRouter
 from accounts import api
-from accounts.api import ProfileViewSet
-
-CiviWikiRouter.register(r"accounts", ProfileViewSet)
 
 urlpatterns = [
     path("account_data/<str:username>/", api.get_user, name="get_user"),

--- a/project/categories/urls.py
+++ b/project/categories/urls.py
@@ -1,4 +1,0 @@
-from core.router import CiviWikiRouter
-from categories.api import CategoryViewSet
-
-CiviWikiRouter.register(r"categories", CategoryViewSet)

--- a/project/core/router.py
+++ b/project/core/router.py
@@ -1,3 +1,11 @@
 from rest_framework import routers
+from accounts.api import ProfileViewSet
+from categories.api import CategoryViewSet
+from threads.views import CiviViewSet, ThreadViewSet
+
 
 CiviWikiRouter = routers.DefaultRouter()
+CiviWikiRouter.register(r"accounts", ProfileViewSet)
+CiviWikiRouter.register(r"categories", CategoryViewSet)
+CiviWikiRouter.register(r"threads", ThreadViewSet)
+CiviWikiRouter.register(r"civis", CiviViewSet)

--- a/project/core/urls.py
+++ b/project/core/urls.py
@@ -25,10 +25,10 @@ from core.router import CiviWikiRouter
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("", include("accounts.urls.urls")),
-    path("api/", include("accounts.urls.api")),
     path("api/v1/", include((CiviWikiRouter.urls, "api"))),
+    path("api/", include("accounts.urls.api")),
     path("api/", include("threads.urls.api")),
+    path("", include("accounts.urls.urls")),
     path("", include("threads.urls.urls")),
     path(
         "inbox/notifications/",

--- a/project/core/urls.py
+++ b/project/core/urls.py
@@ -25,7 +25,7 @@ from core.router import CiviWikiRouter
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("api/v1/", include((CiviWikiRouter.urls, "api"))),
+    path("api/v1/", include(CiviWikiRouter.urls)),
     path("api/", include("accounts.urls.api")),
     path("api/", include("threads.urls.api")),
     path("", include("accounts.urls.urls")),

--- a/project/threads/urls/api.py
+++ b/project/threads/urls/api.py
@@ -1,12 +1,6 @@
 from django.urls import path
-from core.router import CiviWikiRouter
-
 from threads import api
-from threads.views import ThreadViewSet, CiviViewSet
 
-
-CiviWikiRouter.register(r"threads", ThreadViewSet)
-CiviWikiRouter.register(r"civis", CiviViewSet)
 
 urlpatterns = [
     path("thread_data/<int:thread_id>/", api.get_thread, name="get thread"),

--- a/project/threads/urls/api.py
+++ b/project/threads/urls/api.py
@@ -1,23 +1,14 @@
-from django.conf.urls import include
 from django.urls import path
-from rest_framework.routers import DefaultRouter
+from core.router import CiviWikiRouter
 
 from threads import api
 from threads.views import ThreadViewSet, CiviViewSet
-from categories.api import CategoryViewSet
-from accounts.api import ProfileViewSet
 
-router = DefaultRouter(trailing_slash=False)
-router.register(r"threads", ThreadViewSet)
-router.register(r"categories", CategoryViewSet)
-router.register(r"civis", CiviViewSet)
-router.register(r"accounts", ProfileViewSet)
+
+CiviWikiRouter.register(r"threads", ThreadViewSet)
+CiviWikiRouter.register(r"civis", CiviViewSet)
 
 urlpatterns = [
-    path("v1/", include(router.urls)),
-]
-
-urlpatterns += [
     path("thread_data/<int:thread_id>/", api.get_thread, name="get thread"),
     path("civi_data/<int:civi_id>/", api.get_civi, name="get civi"),
     path("threads/<int:thread_id>/civis", api.get_civis, name="get civis"),


### PR DESCRIPTION
Closes #1066


- threads/urls/api.py includes `ProfileViewSet` and `CategoryViewSet`. I remove them.
- Then I realized that registrations for `CiviWikiRouter` should be done in `core/routers.py`. Otherwise, if registration is done in `api.py` files, registrations won't work properly.