### PR TITLE
Update django-notifications (Closes #1244)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,8 @@ Django==3.2.10
 django-cors-headers==3.11.0
 django-extensions==3.1.5
 djangorestframework==3.13.0
-django-notifications-hq==1.6.0
+# django-notifications-hq==1.6.0
+git+https://github.com/django-notifications/django-notifications.git@0fd3f42f71c19ae75348425686a2fe68ffe04fec
 django-storages==1.12.3
 
 whitenoise==5.3.0


### PR DESCRIPTION
Closes #1244

I prefer to keep the current version of `django-notifications` commented.

After adjusting this package, we can update `Django 3.2.10` to `4`. For sure, we have to make small changes but they are not big issues.