### PR TITLE
Fix falied pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: core.settings
         run: |
           cd project
+          poetry run python manage.py collectstatic
           poetry run pytest -p no:warning
       - name: Lint
         uses: py-actions/flake8@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         uses: py-actions/flake8@v2
         with:
           ignore: "E203,W503"
-          exclude: "**/migrations/*.py"
+          exclude: "**/migrations/*.py","*/makemigrations.py"
           max-line-length: "88"
           path: "project"
           plugins: "flake8-bugbear flake8-black"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: core.settings
         run: |
           cd project
-          poetry run python manage.py collectstatic
+          poetry run python manage.py collectstatic --no-input
           poetry run pytest -p no:warning
       - name: Lint
         uses: py-actions/flake8@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         uses: py-actions/flake8@v2
         with:
           ignore: "E203,W503"
-          exclude: "**/migrations/*.py","*/makemigrations.py"
+          exclude: "**/migrations/*.py, **/makemigrations.py"
           max-line-length: "88"
           path: "project"
           plugins: "flake8-bugbear flake8-black"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         uses: py-actions/flake8@v2
         with:
           ignore: "E203,W503"
-          exclude: "**/migrations/*.py, **/makemigrations.py"
+          exclude: "**/migrations/*.py"
           max-line-length: "88"
-          path: "project"
+          path: "./project"
           plugins: "flake8-bugbear flake8-black"

--- a/project/core/settings.py
+++ b/project/core/settings.py
@@ -107,7 +107,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = "/media/"
 
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 
 # Use DATABASE_URL in production
 DATABASE_URL = os.getenv("DATABASE_URL")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = core.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
The issue happens because pytest couldn't find static files during the tests. I am not sure if there is a more efficient way than running collectstatic command. I believe there should be a way to suppress non-existing static file errors during tests.