### PR TITLE
Adding  mypy in our pre-commit settings by adding mirrors-mypy.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,10 @@ repos:
     rev: v0.13.1
     hooks:
       - id: curlylint
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.981 
+    hooks:
+      - id: mypy
+        args: [--no-strict-optional, --ignore-missing-imports]
+        


### PR DESCRIPTION
Closes #1331 
  
## Description

Added mirrors - mypy in the pre - commit setting , for type checking, and making sure that variable and functions in code are correct.
