### PR TITLE
Fix failed tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
         run: poetry install --no-interaction --no-root
       - name: Run migrations
         run: poetry run python project/manage.py migrate
+      - name: Collect static files
+        run: poetry run python project/manage.py collectstatic --no-input
       - name: Run tests
         env:
           CIVIWIKI_LOCAL_NAME: True

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,5 +52,5 @@ jobs:
           ignore: "E203,W503"
           exclude: "**/migrations/*.py"
           max-line-length: "88"
-          path: "project"
+          path: "."
           plugins: "flake8-bugbear flake8-black"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,5 +52,5 @@ jobs:
           ignore: "E203,W503"
           exclude: "**/migrations/*.py"
           max-line-length: "88"
-          path: "."
+          path: "./project"
           plugins: "flake8-bugbear flake8-black"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = core.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
- Add`pytest` configurations to point out where the `settings.py` file is located
- Run collectstatic command before tests

Tests failed because during the tests there is no static files in the project directory. This can be observed by locally deleting the `staticfiles` folder from the project and running `pytest` command
