### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
         run: poetry install --no-interaction --no-root
       - name: Run migrations
         run: poetry run python project/manage.py migrate
+      - name: Collect static files
+        run: poetry run python project/manage.py collectstatic --no-input
       - name: Run tests
         env:
           CIVIWIKI_LOCAL_NAME: True

--- a/project/core/management/commands/makemigrations.py
+++ b/project/core/management/commands/makemigrations.py
@@ -1,4 +1,3 @@
-
 from django.core.management.base import CommandError
 from django.core.management.commands.makemigrations import (
     Command as BaseCommand,
@@ -9,7 +8,7 @@ class Command(BaseCommand):
     def handle(self, *app_labels, name, dry_run, merge, **options):
         if name is None and not dry_run and not merge:
             raise CommandError("-n/--name is required.")
-        
+
         super().handle(
             *app_labels,
             name=name,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = core.settings
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
- Addpytest configurations to point out where the settings.py file is located
- Run collectstatic command before tests

Tests failed because during the tests there is no static files in the project directory. This can be observed by locally deleting the staticfiles folder from the project and running pytest command