### PR TITLE
add poetry caching in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "^3.9"
+      - name: Load cached Poetry installation
+        uses: actions/cache@v2
+        with:
+          path: ~/.local  # the path depends on the OS
+          key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/main.yml') }}
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:


### PR DESCRIPTION

Closes #1383

## Description
Adding cache mechanism to main workflow, we ensure  to reuse poetry install whenever possible. This saves around 10s for each run (~ 14s -> 4s). This is not a huge time reduction but the ratio is (35% time reduction).
