### PR TITLE
Global_nav was duplicated (Bug fix)

### DIFF
--- a/project/threads/templates/threads/thread.html
+++ b/project/threads/templates/threads/thread.html
@@ -19,7 +19,6 @@
 />
 {% endblock extra_css %}
 {% block content %}
-{% include "global_nav.html" %}
 <div id="thread">
   <div class="row" style="margin: 0">
     <div class="col s12 thread-wiki-holder" style="display: none">


### PR DESCRIPTION
Closes #1487
  
## Description
Global_nav was duplicated in this HTML, because it is also loaded from base.html